### PR TITLE
Improve colors on trace view charts

### DIFF
--- a/public/components/traces/trace_view.tsx
+++ b/public/components/traces/trace_view.tsx
@@ -32,8 +32,7 @@ import {
 import React, { useEffect, useState } from 'react';
 import {
   handlePayloadRequest,
-  handleServiceBreakdownRequest,
-  handleSpanDetailRequest,
+  handleTracesChartsRequest,
   handleTraceViewRequest,
 } from '../../requests/traces_request_handler';
 import { CoreDeps } from '../app';
@@ -155,13 +154,14 @@ export function TraceView(props: TraceViewProps) {
 
   const refresh = () => {
     handleTraceViewRequest(props.traceId, props.http, fields, setFields);
-    handleServiceBreakdownRequest(
+    handleTracesChartsRequest(
       props.traceId,
       props.http,
       serviceBreakdownData,
-      setServiceBreakdownData
+      setServiceBreakdownData,
+      spanDetailData,
+      setSpanDetailData
     );
-    handleSpanDetailRequest(props.traceId, props.http, spanDetailData, setSpanDetailData);
     handlePayloadRequest(props.traceId, props.http, payloadData, setPayloadData);
   };
 

--- a/public/requests/queries/traces_queries.ts
+++ b/public/requests/queries/traces_queries.ts
@@ -143,6 +143,11 @@ export const getServiceBreakdownQuery = (traceId: string) => {
       service_type: {
         terms: {
           field: 'serviceName',
+          order: [
+            {
+              total_latency_nanos: 'desc',
+            },
+          ],
         },
         aggs: {
           total_latency_nanos: {

--- a/release-notes/opendistro-for-elasticsearch-trace-analytics.release-notes-1.12.0.0.md
+++ b/release-notes/opendistro-for-elasticsearch-trace-analytics.release-notes-1.12.0.0.md
@@ -6,6 +6,7 @@
 
 ### Enhancements
 * Move service map UI and update status.code definition ([#3](https://github.com/opendistro-for-elasticsearch/trace-analytics/pull/3))
+* Improve colors on trace view charts ([#8](https://github.com/opendistro-for-elasticsearch/trace-analytics/pull/8))
 
 
 ### Maintenance


### PR DESCRIPTION
*Issue #, if available:*
- #7 Original implementation uses `serviceName.hashCode()` to get colors, which ensures the same service always has the same color for all trace views, but doesn't work well as collisions are too often

*Description of changes:*
- Use index number of `serviceName` to get colors, colors of services will only be consistent for the same trace view
- For "Time spent by service", sort services by descending `durationInNanos`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
