### PR TITLE
Extend the indices pattern to match service map data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Distro for Elasticsearch Trace Analytics
 
-The Open Distro for Elasticsearch Trace Analytics plugin provides instant on dashboards in Kibana for users to quickly analyze their logs. The plugin uses aggregated results from two indices, `otel-v1-apm-span-*` and `otel-v1-apm-service-map` created by the otel-trace-raw-processor and service-map-processor, and renders three main views:
+The Open Distro for Elasticsearch Trace Analytics plugin provides instant on dashboards in Kibana for users to quickly analyze their logs. The plugin uses aggregated results from two indices, `otel-v1-apm-span-*` and `otel-v1-apm-service-map*` created by the otel-trace-raw-processor and service-map-processor, and renders three main views:
 
 1. Dashboard: an overview of the trace groups and two charts: error rate and throughput.
 

--- a/common/index.ts
+++ b/common/index.ts
@@ -17,7 +17,7 @@ export const PLUGIN_ID = 'opendistro-trace-analytics';
 export const PLUGIN_NAME = 'Trace Analytics';
 
 export const RAW_INDEX_NAME = 'otel-v1-apm-span-*';
-export const SERVICE_MAP_INDEX_NAME = 'otel-v1-apm-service-map';
+export const SERVICE_MAP_INDEX_NAME = 'otel-v1-apm-service-map*';
 export const DATE_FORMAT = 'MM/DD/YYYY HH:mm:ss';
 export const DATE_PICKER_FORMAT = 'MMM D, YYYY HH:mm:ss';
 export const SERVICE_MAP_MAX_NODES = 500;

--- a/public/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
+++ b/public/components/common/__tests__/__snapshots__/helper_functions.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Helper functions renders no match and missing configuration messages 2`
     }
     body={
       <EuiText>
-        The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+        The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
       </EuiText>
     }
     title={

--- a/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -2295,7 +2295,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
       }
       body={
         <EuiText>
-          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
         </EuiText>
       }
       title={

--- a/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -2337,7 +2337,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+                    The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
                   </div>
                 </EuiText>
               </div>

--- a/public/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -585,7 +585,7 @@ exports[`Services component renders empty services page 1`] = `
       }
       body={
         <EuiText>
-          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
         </EuiText>
       }
       title={

--- a/public/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -627,7 +627,7 @@ exports[`Services component renders empty services page 1`] = `
                   <div
                     className="euiText euiText--medium"
                   >
-                    The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+                    The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
                   </div>
                 </EuiText>
               </div>

--- a/public/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -992,7 +992,7 @@ exports[`Traces component renders empty traces page 1`] = `
                         <div
                           className="euiText euiText--medium"
                         >
-                          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+                          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
                         </div>
                       </EuiText>
                     </div>

--- a/public/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -950,7 +950,7 @@ exports[`Traces component renders empty traces page 1`] = `
             }
             body={
               <EuiText>
-                The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+                The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
               </EuiText>
             }
             title={

--- a/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`Traces table component renders empty traces table message 1`] = `
                       <div
                         className="euiText euiText--medium"
                       >
-                        The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+                        The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
                       </div>
                     </EuiText>
                   </div>

--- a/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Traces table component renders empty traces table message 1`] = `
           }
           body={
             <EuiText>
-              The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map) do not exist or you do not have permission to access them.
+              The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
             </EuiText>
           }
           title={


### PR DESCRIPTION
*Issue #, if available:*
PR in relation with https://discuss.opendistrocommunity.dev/t/trace-analytics-indices-required/4976

*Description of changes:*
Extend the indices pattern to match service map data to `otel-v1-apm-service-map`* so that we can isolate multiple appllications service maps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
