### PR TITLE
Fix index exists query on wildcards

### DIFF
--- a/server/routes/dslRouter.ts
+++ b/server/routes/dslRouter.ts
@@ -28,6 +28,7 @@ export function RegisterDslRouter(router: IRouter) {
     async (context, request, response) => {
       const params: RequestParams.IndicesExists = {
         index: [RAW_INDEX_NAME, SERVICE_MAP_INDEX_NAME],
+        allow_no_indices: false,
       };
       try {
         const resp = await context.core.elasticsearch.legacy.client.callAsCurrentUser(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After we use wildcard in service map index, `allow_no_indices=false` is needed when doing existence check

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.