### PR TITLE
Allow filtering by traceGroup and service

### DIFF
--- a/public/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/common/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -412,7 +412,7 @@ exports[`Search bar components renders search bar 1`] = `
             isLoading={false}
             onChange={[Function]}
             onSearch={[MockFunction]}
-            placeholder="Trace ID, trace group name"
+            placeholder="Trace ID, trace group name, service name"
             value="test"
           >
             <EuiFormControlLayout
@@ -433,7 +433,7 @@ exports[`Search bar components renders search bar 1`] = `
                       data-test-subj="search-bar-input-box"
                       onChange={[Function]}
                       onKeyUp={[Function]}
-                      placeholder="Trace ID, trace group name"
+                      placeholder="Trace ID, trace group name, service name"
                       type="search"
                       value="test"
                     />

--- a/public/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/common/__tests__/helper_functions.test.tsx
@@ -139,12 +139,12 @@ describe('Helper functions', () => {
     ];
     const existsDSL = filtersToDsl(...getTestFilters());
     expect(JSON.stringify(existsDSL)).toEqual(
-      "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"exists\":{\"field\":\"traceGroup\"}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
+      "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"exists\":{\"field\":\"traceGroup.name\"}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
     );
 
     const isDSL = filtersToDsl(...getTestFilters('traceGroup.name', 'is'));
     expect(JSON.stringify(isDSL)).toEqual(
-      "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"term\":{\"traceGroup\":{\"from\":\"100\",\"to\":\"∞\"}}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
+      "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"term\":{\"traceGroup.name\":{\"from\":\"100\",\"to\":\"∞\"}}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
     );
     const isBetweenDSL = filtersToDsl(...getTestFilters('durationInNanos', 'is between'));
     expect(JSON.stringify(isBetweenDSL)).toEqual(

--- a/public/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/common/__tests__/helper_functions.test.tsx
@@ -117,7 +117,7 @@ describe('Helper functions', () => {
     );
     expect(DSL).toEqual(
       JSON.parse(
-        `{"field":"Latency percentile within trace group","operator":"","value":">= 95th","inverted":false,"disabled":false,"custom":{"query":{"bool":{"must":[],"filter":[],"should":[{"bool":{"must":[{"term":{"name":{"value":"order"}}},{"range":{"durationInNanos":{"gte":1000}}}]}}],"must_not":[],"minimum_should_match":1}}}}`
+        `{"field":"Latency percentile within trace group","operator":"","value":">= 95th","inverted":false,"disabled":false,"custom":{"query":{"bool":{"must":[],"filter":[],"should":[{"bool":{"must":[{"term":{"traceGroup.name":{"value":"order"}}},{"range":{"traceGroup.durationInNanos":{"gte":1000}}}]}}],"must_not":[],"minimum_should_match":1}}}}`
       )
     );
   });

--- a/public/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/common/__tests__/helper_functions.test.tsx
@@ -123,7 +123,7 @@ describe('Helper functions', () => {
   });
 
   it('converts filters to DSL', () => {
-    const getTestFilters = (field = 'traceGroup', operator = 'exists') => [
+    const getTestFilters = (field = 'traceGroup.name', operator = 'exists') => [
       [
         {
           field,
@@ -142,7 +142,7 @@ describe('Helper functions', () => {
       "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"exists\":{\"field\":\"traceGroup\"}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
     );
 
-    const isDSL = filtersToDsl(...getTestFilters('traceGroup', 'is'));
+    const isDSL = filtersToDsl(...getTestFilters('traceGroup.name', 'is'));
     expect(JSON.stringify(isDSL)).toEqual(
       "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"term\":{\"traceGroup\":{\"from\":\"100\",\"to\":\"∞\"}}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
     );

--- a/public/components/common/__tests__/helper_functions.test.tsx
+++ b/public/components/common/__tests__/helper_functions.test.tsx
@@ -139,12 +139,12 @@ describe('Helper functions', () => {
     ];
     const existsDSL = filtersToDsl(...getTestFilters());
     expect(JSON.stringify(existsDSL)).toEqual(
-      `{"query":{"bool":{"must":[{"range":{"startTime":{"gte":"now-5m","lte":"now"}}},{"query_string":{"query":"order"}},{"exists":{"field":"traceGroup"}}],"filter":[],"should":[],"must_not":[]}},"custom":{"timeFilter":[{"range":{"startTime":{"gte":"now-5m","lte":"now"}}}],"serviceNames":[],"serviceNamesExclude":[],"traceGroup":[{"from":"100","to":"∞"}],"traceGroupExclude":[],"percentiles":{"query":{"bool":{"should":[]}}}}}`
+      "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"exists\":{\"field\":\"traceGroup\"}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
     );
 
     const isDSL = filtersToDsl(...getTestFilters('traceGroup', 'is'));
     expect(JSON.stringify(isDSL)).toEqual(
-      `{"query":{"bool":{"must":[{"range":{"startTime":{"gte":"now-5m","lte":"now"}}},{"query_string":{"query":"order"}},{"term":{"traceGroup":{"from":"100","to":"∞"}}}],"filter":[],"should":[],"must_not":[]}},"custom":{"timeFilter":[{"range":{"startTime":{"gte":"now-5m","lte":"now"}}}],"serviceNames":[],"serviceNamesExclude":[],"traceGroup":[{"from":"100","to":"∞"}],"traceGroupExclude":[],"percentiles":{"query":{"bool":{"should":[]}}}}}`
+      "{\"query\":{\"bool\":{\"must\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}},{\"query_string\":{\"query\":\"order\"}},{\"term\":{\"traceGroup\":{\"from\":\"100\",\"to\":\"∞\"}}}],\"filter\":[],\"should\":[],\"must_not\":[]}},\"custom\":{\"timeFilter\":[{\"range\":{\"startTime\":{\"gte\":\"now-5m\",\"lte\":\"now\"}}}],\"serviceNames\":[],\"serviceNamesExclude\":[],\"traceGroup\":[],\"traceGroupExclude\":[],\"percentiles\":{\"query\":{\"bool\":{\"should\":[]}}}}}"
     );
     const isBetweenDSL = filtersToDsl(...getTestFilters('durationInNanos', 'is between'));
     expect(JSON.stringify(isBetweenDSL)).toEqual(

--- a/public/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
+++ b/public/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
@@ -6,7 +6,13 @@ exports[`Filter popover component renders filter popover 1`] = `
   filterFieldOptions={
     Array [
       Object {
+        "label": "traceID",
+      },
+      Object {
         "label": "traceGroup",
+      },
+      Object {
+        "label": "serviceName",
       },
       Object {
         "label": "status.code",
@@ -97,7 +103,13 @@ exports[`Filter popover component renders filter popover 1`] = `
                     options={
                       Array [
                         Object {
+                          "label": "traceID",
+                        },
+                        Object {
                           "label": "traceGroup",
+                        },
+                        Object {
+                          "label": "serviceName",
                         },
                         Object {
                           "label": "status.code",

--- a/public/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
+++ b/public/components/common/filters/__tests__/__snapshots__/filter_edit_popover.test.tsx.snap
@@ -6,22 +6,19 @@ exports[`Filter popover component renders filter popover 1`] = `
   filterFieldOptions={
     Array [
       Object {
-        "label": "traceID",
-      },
-      Object {
-        "label": "traceGroup",
+        "label": "traceGroup.name",
       },
       Object {
         "label": "serviceName",
       },
       Object {
-        "label": "status.code",
+        "label": "error",
       },
       Object {
         "label": "status.message",
       },
       Object {
-        "label": "durationInNanos",
+        "label": "latency",
       },
     ]
   }
@@ -103,22 +100,19 @@ exports[`Filter popover component renders filter popover 1`] = `
                     options={
                       Array [
                         Object {
-                          "label": "traceID",
-                        },
-                        Object {
-                          "label": "traceGroup",
+                          "label": "traceGroup.name",
                         },
                         Object {
                           "label": "serviceName",
                         },
                         Object {
-                          "label": "status.code",
+                          "label": "error",
                         },
                         Object {
                           "label": "status.message",
                         },
                         Object {
-                          "label": "durationInNanos",
+                          "label": "latency",
                         },
                       ]
                     }

--- a/public/components/common/filters/__tests__/filter_edit_popover.test.tsx
+++ b/public/components/common/filters/__tests__/filter_edit_popover.test.tsx
@@ -40,7 +40,7 @@ describe('Filter popover component', () => {
     wrapper
       .find('input')
       .at(0)
-      .simulate('change', [{ label: 'traceGroup' }]);
+      .simulate('change', [{ label: 'traceGroup.name' }]);
     wrapper
       .find('input')
       .at(1)

--- a/public/components/common/filters/__tests__/filter_helpers.test.tsx
+++ b/public/components/common/filters/__tests__/filter_helpers.test.tsx
@@ -19,7 +19,6 @@ import {
   getFilterFields,
   getInvertedOperator,
   getOperatorOptions,
-  getType,
   getValidFilterFields,
   getValueComponent,
 } from '../filter_helpers';
@@ -30,12 +29,11 @@ describe('Filter helper functions', () => {
   it('returns fields by page', () => {
     const fields = getFilterFields('dashboard');
     expect(fields).toEqual([
-      'traceID',
       'traceGroup.name',
       'serviceName',
-      'status.code',
+      'error',
       'status.message',
-      'durationInNanos',
+      'latency',
     ]);
   });
 
@@ -43,27 +41,20 @@ describe('Filter helper functions', () => {
     const dashboardFields = getValidFilterFields('dashboard');
     const servicesFields = getValidFilterFields('services');
     expect(dashboardFields).toEqual([
-      'traceID',
       'traceGroup.name',
       'serviceName',
-      'status.code',
+      'error',
       'status.message',
-      'durationInNanos',
+      'latency',
       'Latency percentile within trace group',
     ]);
     expect(servicesFields).toEqual([
-      'traceId',
       'traceGroup.name',
       'serviceName',
-      'status.code',
+      'error',
       'status.message',
-      'durationInNanos',
+      'latency',
     ]);
-  });
-
-  it('returns types by fields', () => {
-    const durationType = getType('durationInNanos');
-    expect(durationType).toEqual('long');
   });
 
   it('returns inverted operators', () => {
@@ -101,7 +92,7 @@ describe('Filter helper functions', () => {
 
   it('renders textfield filter', () => {
     const setValue = jest.fn((v) => {});
-    const wrapper = mount(getValueComponent('is', 0, setValue));
+    const wrapper = mount(getValueComponent('serviceName', 'is', 0, setValue));
     expect(wrapper).toMatchSnapshot();
 
     wrapper.find('input').simulate('change', { target: { value: '100' } });
@@ -110,7 +101,9 @@ describe('Filter helper functions', () => {
 
   it('renders range field filter', () => {
     const setValue = jest.fn((v) => {});
-    const wrapper = mount(getValueComponent('is not between', { from: '0', to: '100' }, setValue));
+    const wrapper = mount(
+      getValueComponent('latency', 'is not between', { from: '0', to: '100' }, setValue)
+    );
     expect(wrapper).toMatchSnapshot();
 
     wrapper

--- a/public/components/common/filters/__tests__/filter_helpers.test.tsx
+++ b/public/components/common/filters/__tests__/filter_helpers.test.tsx
@@ -31,7 +31,7 @@ describe('Filter helper functions', () => {
     const fields = getFilterFields('dashboard');
     expect(fields).toEqual([
       'traceID',
-      'traceGroup',
+      'traceGroup.name',
       'serviceName',
       'status.code',
       'status.message',
@@ -44,7 +44,7 @@ describe('Filter helper functions', () => {
     const servicesFields = getValidFilterFields('services');
     expect(dashboardFields).toEqual([
       'traceID',
-      'traceGroup',
+      'traceGroup.name',
       'serviceName',
       'status.code',
       'status.message',
@@ -53,7 +53,7 @@ describe('Filter helper functions', () => {
     ]);
     expect(servicesFields).toEqual([
       'traceId',
-      'traceGroup',
+      'traceGroup.name',
       'serviceName',
       'status.code',
       'status.message',

--- a/public/components/common/filters/__tests__/filter_helpers.test.tsx
+++ b/public/components/common/filters/__tests__/filter_helpers.test.tsx
@@ -29,20 +29,36 @@ describe('Filter helper functions', () => {
 
   it('returns fields by page', () => {
     const fields = getFilterFields('dashboard');
-    expect(fields).toEqual(['traceGroup', 'status.code', 'status.message', 'durationInNanos']);
+    expect(fields).toEqual([
+      'traceID',
+      'traceGroup',
+      'serviceName',
+      'status.code',
+      'status.message',
+      'durationInNanos',
+    ]);
   });
 
   it('returns valid fields by page', () => {
     const dashboardFields = getValidFilterFields('dashboard');
     const servicesFields = getValidFilterFields('services');
     expect(dashboardFields).toEqual([
+      'traceID',
       'traceGroup',
+      'serviceName',
       'status.code',
       'status.message',
       'durationInNanos',
       'Latency percentile within trace group',
     ]);
-    expect(servicesFields).toEqual([]);
+    expect(servicesFields).toEqual([
+      'traceId',
+      'traceGroup',
+      'serviceName',
+      'status.code',
+      'status.message',
+      'durationInNanos',
+    ]);
   });
 
   it('returns types by fields', () => {

--- a/public/components/common/filters/filter_edit_popover.tsx
+++ b/public/components/common/filters/filter_edit_popover.tsx
@@ -89,11 +89,19 @@ export function FilterEditPopover(props: {
         </EuiFlexItem>
       </EuiFlexGroup>
       {selectedOperatorOptions.length > 0 &&
-        getValueComponent(selectedOperatorOptions[0].label, filterValue, setFilterValue)}
+        getValueComponent(
+          selectedFieldOptions[0].label,
+          selectedOperatorOptions[0].label,
+          filterValue,
+          setFilterValue
+        )}
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButtonEmpty data-test-subj="filter-popover-cancel-button" onClick={props.closePopover}>
+          <EuiButtonEmpty
+            data-test-subj="filter-popover-cancel-button"
+            onClick={props.closePopover}
+          >
             Cancel
           </EuiButtonEmpty>
         </EuiFlexItem>

--- a/public/components/common/filters/filter_helpers.tsx
+++ b/public/components/common/filters/filter_helpers.tsx
@@ -17,17 +17,11 @@ import { EuiFieldText, EuiFormControlLayoutDelimited, EuiFormRow, EuiSpacer } fr
 import _ from 'lodash';
 import React from 'react';
 
-const getFields = (page) =>
+const getFields = (page: 'dashboard' | 'traces' | 'services') =>
   ({
-    dashboard: ['traceGroup', 'status.code', 'status.message', 'durationInNanos'],
-    traces: [
-      'traceId',
-      'traceGroup',
-      'status.code',
-      'status.message',
-      'durationInNanos',
-    ],
-    services: [],
+    dashboard: ['traceID', 'traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
+    traces: ['traceId', 'traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
+    services: ['traceId', 'traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
   }[page]);
 // filters will take effect and can be manually added
 export const getFilterFields = (page: 'dashboard' | 'traces' | 'services') => getFields(page);

--- a/public/components/common/filters/filter_helpers.tsx
+++ b/public/components/common/filters/filter_helpers.tsx
@@ -19,9 +19,9 @@ import React from 'react';
 
 const getFields = (page: 'dashboard' | 'traces' | 'services') =>
   ({
-    dashboard: ['traceID', 'traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
+    dashboard: ['traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
     traces: ['traceId', 'traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
-    services: ['traceId', 'traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
+    services: ['traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
   }[page]);
 // filters will take effect and can be manually added
 export const getFilterFields = (page: 'dashboard' | 'traces' | 'services') => getFields(page);

--- a/public/components/common/filters/filter_helpers.tsx
+++ b/public/components/common/filters/filter_helpers.tsx
@@ -25,9 +25,9 @@ import React from 'react';
 
 const getFields = (page: 'dashboard' | 'traces' | 'services') =>
   ({
-    dashboard: ['traceGroup', 'serviceName', 'error', 'status.message', 'latency'],
-    traces: ['traceId', 'traceGroup', 'serviceName', 'error', 'status.message', 'latency'],
-    services: ['traceGroup', 'serviceName', 'error', 'status.message', 'latency'],
+    dashboard: ['traceGroup.name', 'serviceName', 'error', 'status.message', 'latency'],
+    traces: ['traceId', 'traceGroup.name', 'serviceName', 'error', 'status.message', 'latency'],
+    services: ['traceGroup.name', 'serviceName', 'error', 'status.message', 'latency'],
   }[page]);
 // filters will take effect and can be manually added
 export const getFilterFields = (page: 'dashboard' | 'traces' | 'services') => getFields(page);

--- a/public/components/common/filters/filter_helpers.tsx
+++ b/public/components/common/filters/filter_helpers.tsx
@@ -13,15 +13,21 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiFieldText, EuiFormControlLayoutDelimited, EuiFormRow, EuiSpacer } from '@elastic/eui';
+import {
+  EuiComboBox,
+  EuiFieldText,
+  EuiFormControlLayoutDelimited,
+  EuiFormRow,
+  EuiSpacer,
+} from '@elastic/eui';
 import _ from 'lodash';
 import React from 'react';
 
 const getFields = (page: 'dashboard' | 'traces' | 'services') =>
   ({
-    dashboard: ['traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
-    traces: ['traceId', 'traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
-    services: ['traceGroup', 'serviceName', 'status.code', 'status.message', 'durationInNanos'],
+    dashboard: ['traceGroup', 'serviceName', 'error', 'status.message', 'latency'],
+    traces: ['traceId', 'traceGroup', 'serviceName', 'error', 'status.message', 'latency'],
+    services: ['traceGroup', 'serviceName', 'error', 'status.message', 'latency'],
   }[page]);
 // filters will take effect and can be manually added
 export const getFilterFields = (page: 'dashboard' | 'traces' | 'services') => getFields(page);
@@ -32,7 +38,7 @@ export const getValidFilterFields = (page: 'dashboard' | 'traces' | 'services') 
   return fields;
 };
 
-export const getType = (field: string): string => {
+const getType = (field: string): string => {
   const typeMapping = {
     attributes: {
       host: {
@@ -57,6 +63,7 @@ export const getType = (field: string): string => {
       port: 'long',
     },
     durationInNanos: 'long',
+    latency: 'long',
     endTime: 'date_nanos',
     startTime: 'date_nanos',
   };
@@ -115,7 +122,12 @@ export const getOperatorOptions = (field: string) => {
   return operators;
 };
 
-export const getValueComponent = (operator: string, value: any, setValue: (v: any) => void) => {
+export const getValueComponent = (
+  field: string,
+  operator: string,
+  value: any,
+  setValue: (v: any) => void
+) => {
   const textField = (
     <>
       <EuiSpacer size="s" />
@@ -176,6 +188,34 @@ export const getValueComponent = (operator: string, value: any, setValue: (v: an
       </>
     );
   };
+
+  const getComboBoxField = () => {
+    return (
+      <>
+        <EuiSpacer size="s" />
+        <EuiFormRow label={'Value'}>
+          <EuiComboBox
+            placeholder="Select a value"
+            options={[
+              {
+                label: 'true',
+              },
+              {
+                label: 'false',
+              },
+            ]}
+            onChange={setValue}
+            selectedOptions={value || []}
+            singleSelection={true}
+          />
+        </EuiFormRow>
+      </>
+    );
+  };
+
+  if (field === 'error' && (operator === 'is' || operator === 'is not')) {
+    return getComboBoxField();
+  }
 
   const valueMapping = {
     is: textField,

--- a/public/components/common/filters/filters.tsx
+++ b/public/components/common/filters/filters.tsx
@@ -257,7 +257,9 @@ export function Filters(props: FiltersOwnProps) {
       const value =
         typeof filter.value === 'string'
           ? filter.value
-          : `${filter.value.from} to ${filter.value.to}`;
+          : Array.isArray(filter.value)  // combo box
+          ? filter.value[0].label
+          : `${filter.value.from} to ${filter.value.to}`;  // range selector
       const filterLabel = filter.inverted ? (
         <>
           <EuiTextColor color={disabled ? 'default' : 'danger'}>{'NOT '}</EuiTextColor>

--- a/public/components/common/helper_functions.tsx
+++ b/public/components/common/helper_functions.tsx
@@ -160,6 +160,8 @@ export function getServiceMapTargetResources(map: ServiceObject, serviceName: st
 
 export function calculateTicks(min, max, numTicks = 5) {
   if (min >= max) return calculateTicks(0, Math.max(1, max), numTicks);
+  min = Math.floor(min);
+  max = Math.ceil(max);
 
   const range = max - min;
   const minInterval = range / numTicks;

--- a/public/components/common/helper_functions.tsx
+++ b/public/components/common/helper_functions.tsx
@@ -98,7 +98,7 @@ export function milliToNanoSec(ms: number) {
 }
 
 export function getServiceMapScaleColor(percent, idSelected) {
-  return serviceMapColorPalette[idSelected][Math.min(100, Math.max(0, Math.floor(percent * 100)))];
+  return serviceMapColorPalette[idSelected][Math.min(99, Math.max(0, Math.floor(percent * 100)))];
 }
 
 // construct vis-js graph from ServiceObject

--- a/public/components/common/helper_functions.tsx
+++ b/public/components/common/helper_functions.tsx
@@ -322,16 +322,16 @@ export const filtersToDsl = (
         return;
       }
 
-      if (
-        filter.field === 'serviceName' &&
-        (filter.operator === 'is' || filter.operator === 'is not')
-      ) {
-        DSL.custom[filter.inverted ? 'serviceNamesExclude' : 'serviceNames'].push(filter.value);
-      }
+      // if (
+      //   filter.field === 'serviceName' &&
+      //   (filter.operator === 'is' || filter.operator === 'is not')
+      // ) {
+      //   DSL.custom[filter.inverted ? 'serviceNamesExclude' : 'serviceNames'].push(filter.value);
+      // }
 
-      if (filter.field === 'traceGroup') {
-        DSL.custom[filter.inverted ? 'traceGroupExclude' : 'traceGroup'].push(filter.value);
-      }
+      // if (filter.field === 'traceGroup') {
+      //   DSL.custom[filter.inverted ? 'traceGroupExclude' : 'traceGroup'].push(filter.value);
+      // }
 
       let filterQuery = {};
       switch (filter.operator) {

--- a/public/components/common/helper_functions.tsx
+++ b/public/components/common/helper_functions.tsx
@@ -239,20 +239,21 @@ export const getPercentileFilter = (
         must: [
           {
             term: {
-              name: {
+              'traceGroup.name': {
                 value: map.traceGroupName,
               },
             },
           },
           {
             range: {
-              durationInNanos: map.durationFilter,
+              'traceGroup.durationInNanos': map.durationFilter,
             },
           },
         ],
       },
     });
   });
+  console.log('DSL', DSL);
   return {
     field: 'Latency percentile within trace group',
     operator: '',

--- a/public/components/common/helper_functions.tsx
+++ b/public/components/common/helper_functions.tsx
@@ -324,22 +324,12 @@ export const filtersToDsl = (
         return;
       }
 
-      // if (
-      //   filter.field === 'serviceName' &&
-      //   (filter.operator === 'is' || filter.operator === 'is not')
-      // ) {
-      //   DSL.custom[filter.inverted ? 'serviceNamesExclude' : 'serviceNames'].push(filter.value);
-      // }
-
-      // if (filter.field === 'traceGroup') {
-      //   DSL.custom[filter.inverted ? 'traceGroupExclude' : 'traceGroup'].push(filter.value);
-      // }
-
       let filterQuery = {};
       let field = filter.field;
-      if (field === 'latency') field = 'durationInNanos';
-      else if (field === 'error') field = 'status.code';
+      if (field === 'latency') field = 'traceGroup.durationInNanos';
+      else if (field === 'error') field = 'traceGroup.statusCode';
       let value;
+
       switch (filter.operator) {
         case 'exists':
         case 'does not exist':
@@ -354,9 +344,9 @@ export const filtersToDsl = (
         case 'is not':
           value = filter.value;
           // latency and error are not actual fields, need to convert first
-          if (field === 'durationInNanos') {
+          if (field === 'traceGroup.durationInNanos') {
             value = milliToNanoSec(value);
-          } else if (field === 'status.code') {
+          } else if (field === 'traceGroup.statusCode') {
             value = value[0].label === 'true' ? '2' : '0';
           }
 
@@ -372,7 +362,7 @@ export const filtersToDsl = (
           const range: { gte?: string; lte?: string } = {};
           if (!filter.value.from.includes('\u221E')) range.gte = filter.value.from;
           if (!filter.value.to.includes('\u221E')) range.lte = filter.value.to;
-          if (field === 'durationInNanos') {
+          if (field === 'traceGroup.durationInNanos') {
             if (range.lte) range.lte = milliToNanoSec(parseInt(range.lte || '')).toString();
             if (range.gte) range.gte = milliToNanoSec(parseInt(range.gte || '')).toString();
           }

--- a/public/components/common/plots/__tests__/__snapshots__/error_rate_plt_.test.tsx.snap
+++ b/public/components/common/plots/__tests__/__snapshots__/error_rate_plt_.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Error rate plot component renders error rate plot 1`] = `
     }
   >
     <PanelTitle
-      title="Error rate over time"
+      title="Trace error rate over time"
     />
     <EuiHorizontalRule
       margin="m"

--- a/public/components/common/plots/__tests__/__snapshots__/throughput_plt.test.tsx.snap
+++ b/public/components/common/plots/__tests__/__snapshots__/throughput_plt.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Throughput plot component renders throughput plot 1`] = `
     }
   >
     <PanelTitle
-      title="Throughput over time"
+      title="Traces over time"
     />
     <EuiHorizontalRule
       margin="m"

--- a/public/components/common/plots/error_rate_plt.tsx
+++ b/public/components/common/plots/error_rate_plt.tsx
@@ -95,7 +95,7 @@ export function ErrorRatePlt(props: {
   return (
     <>
       <EuiPanel style={{ minWidth: 433, minHeight: 308 }}>
-        <PanelTitle title="Error rate over time" />
+        <PanelTitle title="Trace error rate over time" />
         <EuiHorizontalRule margin="m" />
         {props.items?.items?.length > 0 ? (
           <Plt data={props.items.items} layout={layout} onClickHandler={onClick} />

--- a/public/components/common/plots/service_map.tsx
+++ b/public/components/common/plots/service_map.tsx
@@ -124,6 +124,7 @@ export function ServiceMap({
           inverted: false,
           disabled: false,
         });
+        window.scrollTo({ left: 0, top: 0, behavior: 'smooth' });
       }
     },
     hoverNode: (event) => {},

--- a/public/components/common/plots/throughput_plt.tsx
+++ b/public/components/common/plots/throughput_plt.tsx
@@ -95,7 +95,7 @@ export function ThroughputPlt(props: {
   return (
     <>
       <EuiPanel style={{ minWidth: 433, minHeight: 308 }}>
-        <PanelTitle title="Throughput over time" />
+        <PanelTitle title="Traces over time" />
         <EuiHorizontalRule margin="m" />
         {props.items?.items?.length > 0 ? (
           <Plt data={props.items.items} layout={layout} onClickHandler={onClick} />

--- a/public/components/common/search_bar.tsx
+++ b/public/components/common/search_bar.tsx
@@ -67,7 +67,7 @@ export function SearchBar(props: SearchBarOwnProps) {
             <EuiFieldSearch
               fullWidth
               isClearable={false}
-              placeholder="Trace ID, trace group name"
+              placeholder="Trace ID, trace group name, service name"
               data-test-subj="search-bar-input-box"
               value={query}
               onChange={(e) => {

--- a/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`Dashboard component renders dashboard 1`] = `
               isLoading={false}
               onChange={[Function]}
               onSearch={[Function]}
-              placeholder="Trace ID, trace group name"
+              placeholder="Trace ID, trace group name, service name"
               value=""
             >
               <EuiFormControlLayout
@@ -132,7 +132,7 @@ exports[`Dashboard component renders dashboard 1`] = `
                         data-test-subj="search-bar-input-box"
                         onChange={[Function]}
                         onKeyUp={[Function]}
-                        placeholder="Trace ID, trace group name"
+                        placeholder="Trace ID, trace group name, service name"
                         type="search"
                         value=""
                       />
@@ -1139,39 +1139,24 @@ exports[`Dashboard component renders dashboard 1`] = `
     <div
       className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--alignItemsBaseline euiFlexGroup--directionRow euiFlexGroup--responsive"
     >
-      <EuiFlexItem>
+      <EuiFlexItem
+        grow={4}
+      >
         <div
-          className="euiFlexItem"
+          className="euiFlexItem euiFlexItem--flexGrow4"
         >
-          <ErrorRatePlt
-            items={
-              Object {
-                "fixedInterval": "1h",
-                "items": Array [],
-              }
-            }
-            setEndTime={[MockFunction]}
-            setStartTime={[MockFunction]}
+          <ServiceMap
+            addFilter={[Function]}
+            idSelected="latency"
+            serviceMap={Object {}}
+            setIdSelected={[Function]}
           >
-            <EuiPanel
-              style={
-                Object {
-                  "minHeight": 308,
-                  "minWidth": 433,
-                }
-              }
-            >
+            <EuiPanel>
               <div
                 className="euiPanel euiPanel--paddingMedium"
-                style={
-                  Object {
-                    "minHeight": 308,
-                    "minWidth": 433,
-                  }
-                }
               >
                 <PanelTitle
-                  title="Error rate over time"
+                  title="Service map"
                 >
                   <EuiText
                     size="m"
@@ -1182,11 +1167,304 @@ exports[`Dashboard component renders dashboard 1`] = `
                       <span
                         className="panel-title"
                       >
-                        Error rate over time
+                        Service map
                       </span>
                     </div>
                   </EuiText>
                 </PanelTitle>
+                <EuiSpacer
+                  size="m"
+                >
+                  <div
+                    className="euiSpacer euiSpacer--m"
+                  />
+                </EuiSpacer>
+                <EuiButtonGroup
+                  buttonSize="s"
+                  color="text"
+                  idSelected="latency"
+                  onChange={[Function]}
+                  options={
+                    Array [
+                      Object {
+                        "id": "latency",
+                        "label": "Latency",
+                      },
+                      Object {
+                        "id": "error_rate",
+                        "label": "Error rate",
+                      },
+                      Object {
+                        "id": "throughput",
+                        "label": "Throughput",
+                      },
+                    ]
+                  }
+                >
+                  <fieldset
+                    className="euiButtonGroup__fieldset"
+                  >
+                    <div
+                      className="euiButtonGroup euiButtonGroup--s"
+                    >
+                      <EuiButtonToggle
+                        className="euiButtonGroup__button euiButtonGroup__button--selected"
+                        color="text"
+                        fill={true}
+                        id="latency"
+                        isSelected={true}
+                        key="0"
+                        label="Latency"
+                        onChange={[Function]}
+                        size="s"
+                        toggleClassName="euiButtonGroup__toggle"
+                        type="single"
+                      >
+                        <EuiToggle
+                          checked={true}
+                          className="euiButtonToggle__wrapper euiButtonGroup__toggle"
+                          inputClassName="euiButtonToggle__input"
+                          label="Latency"
+                          onChange={[Function]}
+                          title="Latency"
+                          type="single"
+                        >
+                          <div
+                            className="euiToggle euiToggle--checked euiButtonToggle__wrapper euiButtonGroup__toggle"
+                          >
+                            <input
+                              aria-label="Latency"
+                              checked={true}
+                              className="euiToggle__input euiButtonToggle__input"
+                              onChange={[Function]}
+                              title="Latency"
+                              type="radio"
+                            />
+                            <EuiButton
+                              className="euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected"
+                              color="text"
+                              fill={true}
+                              id="latency"
+                              size="s"
+                              tabIndex={-1}
+                            >
+                              <EuiButtonDisplay
+                                className="euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected"
+                                color="text"
+                                disabled={false}
+                                element="button"
+                                fill={true}
+                                id="latency"
+                                isDisabled={false}
+                                size="s"
+                                tabIndex={-1}
+                                type="button"
+                              >
+                                <button
+                                  className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
+                                  disabled={false}
+                                  id="latency"
+                                  tabIndex={-1}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButton__content"
+                                    >
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Latency
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </div>
+                        </EuiToggle>
+                      </EuiButtonToggle>
+                      <EuiButtonToggle
+                        className="euiButtonGroup__button"
+                        color="text"
+                        fill={false}
+                        id="error_rate"
+                        isSelected={false}
+                        key="1"
+                        label="Error rate"
+                        onChange={[Function]}
+                        size="s"
+                        toggleClassName="euiButtonGroup__toggle"
+                        type="single"
+                      >
+                        <EuiToggle
+                          checked={false}
+                          className="euiButtonToggle__wrapper euiButtonGroup__toggle"
+                          inputClassName="euiButtonToggle__input"
+                          label="Error rate"
+                          onChange={[Function]}
+                          title="Error rate"
+                          type="single"
+                        >
+                          <div
+                            className="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+                          >
+                            <input
+                              aria-label="Error rate"
+                              checked={false}
+                              className="euiToggle__input euiButtonToggle__input"
+                              onChange={[Function]}
+                              title="Error rate"
+                              type="radio"
+                            />
+                            <EuiButton
+                              className="euiButtonToggle euiButtonGroup__button"
+                              color="text"
+                              fill={false}
+                              id="error_rate"
+                              size="s"
+                              tabIndex={-1}
+                            >
+                              <EuiButtonDisplay
+                                className="euiButtonToggle euiButtonGroup__button"
+                                color="text"
+                                disabled={false}
+                                element="button"
+                                fill={false}
+                                id="error_rate"
+                                isDisabled={false}
+                                size="s"
+                                tabIndex={-1}
+                                type="button"
+                              >
+                                <button
+                                  className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+                                  disabled={false}
+                                  id="error_rate"
+                                  tabIndex={-1}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButton__content"
+                                    >
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Error rate
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </div>
+                        </EuiToggle>
+                      </EuiButtonToggle>
+                      <EuiButtonToggle
+                        className="euiButtonGroup__button"
+                        color="text"
+                        fill={false}
+                        id="throughput"
+                        isSelected={false}
+                        key="2"
+                        label="Throughput"
+                        onChange={[Function]}
+                        size="s"
+                        toggleClassName="euiButtonGroup__toggle"
+                        type="single"
+                      >
+                        <EuiToggle
+                          checked={false}
+                          className="euiButtonToggle__wrapper euiButtonGroup__toggle"
+                          inputClassName="euiButtonToggle__input"
+                          label="Throughput"
+                          onChange={[Function]}
+                          title="Throughput"
+                          type="single"
+                        >
+                          <div
+                            className="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+                          >
+                            <input
+                              aria-label="Throughput"
+                              checked={false}
+                              className="euiToggle__input euiButtonToggle__input"
+                              onChange={[Function]}
+                              title="Throughput"
+                              type="radio"
+                            />
+                            <EuiButton
+                              className="euiButtonToggle euiButtonGroup__button"
+                              color="text"
+                              fill={false}
+                              id="throughput"
+                              size="s"
+                              tabIndex={-1}
+                            >
+                              <EuiButtonDisplay
+                                className="euiButtonToggle euiButtonGroup__button"
+                                color="text"
+                                disabled={false}
+                                element="button"
+                                fill={false}
+                                id="throughput"
+                                isDisabled={false}
+                                size="s"
+                                tabIndex={-1}
+                                type="button"
+                              >
+                                <button
+                                  className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+                                  disabled={false}
+                                  id="throughput"
+                                  tabIndex={-1}
+                                  type="button"
+                                >
+                                  <EuiButtonContent
+                                    className="euiButton__content"
+                                    iconSide="left"
+                                    textProps={
+                                      Object {
+                                        "className": "euiButton__text",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="euiButtonContent euiButton__content"
+                                    >
+                                      <span
+                                        className="euiButton__text"
+                                      >
+                                        Throughput
+                                      </span>
+                                    </span>
+                                  </EuiButtonContent>
+                                </button>
+                              </EuiButtonDisplay>
+                            </EuiButton>
+                          </div>
+                        </EuiToggle>
+                      </EuiButtonToggle>
+                    </div>
+                  </fieldset>
+                </EuiButtonGroup>
                 <EuiHorizontalRule
                   margin="m"
                 >
@@ -1194,213 +1472,488 @@ exports[`Dashboard component renders dashboard 1`] = `
                     className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
                   />
                 </EuiHorizontalRule>
-                <NoMatchMessage
-                  size="s"
+                <EuiFlexGroup
+                  alignItems="center"
+                  gutterSize="s"
                 >
-                  <EuiSpacer
-                    size="s"
+                  <div
+                    className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
                   >
-                    <div
-                      className="euiSpacer euiSpacer--s"
-                    />
-                  </EuiSpacer>
-                  <EuiEmptyPrompt
-                    body={
-                      <EuiText>
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                      </EuiText>
-                    }
-                    title={
-                      <h2>
-                        No matches
-                      </h2>
-                    }
-                  >
-                    <div
-                      className="euiEmptyPrompt"
+                    <EuiFlexItem
+                      grow={false}
                     >
-                      <EuiTextColor
-                        color="subdued"
+                      <div
+                        className="euiFlexItem euiFlexItem--flexGrowZero"
                       >
-                        <span
-                          className="euiTextColor euiTextColor--subdued"
+                        <EuiText>
+                          <div
+                            className="euiText euiText--medium"
+                          >
+                            Focus on
+                          </div>
+                        </EuiText>
+                      </div>
+                    </EuiFlexItem>
+                    <EuiFlexItem>
+                      <div
+                        className="euiFlexItem"
+                      >
+                        <EuiFieldSearch
+                          compressed={false}
+                          fullWidth={false}
+                          incremental={false}
+                          isClearable={true}
+                          isInvalid={false}
+                          isLoading={false}
+                          onChange={[Function]}
+                          onSearch={[Function]}
+                          placeholder="Service name"
+                          value=""
                         >
-                          <EuiTitle
-                            size="m"
-                          >
-                            <h2
-                              className="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
-                          </EuiTitle>
-                          <EuiSpacer
-                            size="m"
+                          <EuiFormControlLayout
+                            compressed={false}
+                            fullWidth={false}
+                            icon="search"
+                            isLoading={false}
                           >
                             <div
-                              className="euiSpacer euiSpacer--m"
-                            />
-                          </EuiSpacer>
-                          <EuiText>
-                            <div
-                              className="euiText euiText--medium"
+                              className="euiFormControlLayout"
                             >
-                              <EuiText>
-                                <div
-                                  className="euiText euiText--medium"
+                              <div
+                                className="euiFormControlLayout__childrenWrapper"
+                              >
+                                <EuiValidatableControl
+                                  isInvalid={false}
                                 >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </EuiText>
+                                  <input
+                                    className="euiFieldSearch euiFieldSearch-isClearable"
+                                    onChange={[Function]}
+                                    onKeyUp={[Function]}
+                                    placeholder="Service name"
+                                    type="search"
+                                    value=""
+                                  />
+                                </EuiValidatableControl>
+                                <EuiFormControlLayoutIcons
+                                  icon="search"
+                                  isLoading={false}
+                                >
+                                  <div
+                                    className="euiFormControlLayoutIcons"
+                                  >
+                                    <EuiFormControlLayoutCustomIcon
+                                      type="search"
+                                    >
+                                      <span
+                                        className="euiFormControlLayoutCustomIcon"
+                                      >
+                                        <EuiIcon
+                                          aria-hidden="true"
+                                          className="euiFormControlLayoutCustomIcon__icon"
+                                          type="search"
+                                        >
+                                          <EuiIconSearch
+                                            aria-hidden={true}
+                                            className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                            focusable="false"
+                                            role="img"
+                                            style={null}
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                              focusable="false"
+                                              height={16}
+                                              role="img"
+                                              style={null}
+                                              viewBox="0 0 16 16"
+                                              width={16}
+                                              xmlns="http://www.w3.org/2000/svg"
+                                            >
+                                              <path
+                                                d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                                              />
+                                            </svg>
+                                          </EuiIconSearch>
+                                        </EuiIcon>
+                                      </span>
+                                    </EuiFormControlLayoutCustomIcon>
+                                  </div>
+                                </EuiFormControlLayoutIcons>
+                              </div>
                             </div>
-                          </EuiText>
-                        </span>
-                      </EuiTextColor>
-                    </div>
-                  </EuiEmptyPrompt>
-                  <EuiSpacer
+                          </EuiFormControlLayout>
+                        </EuiFieldSearch>
+                      </div>
+                    </EuiFlexItem>
+                  </div>
+                </EuiFlexGroup>
+                <EuiSpacer>
+                  <div
+                    className="euiSpacer euiSpacer--l"
+                  />
+                </EuiSpacer>
+                <div
+                  style={
+                    Object {
+                      "minHeight": 434,
+                    }
+                  }
+                >
+                  <NoMatchMessage
                     size="s"
                   >
-                    <div
-                      className="euiSpacer euiSpacer--s"
-                    />
-                  </EuiSpacer>
-                </NoMatchMessage>
+                    <EuiSpacer
+                      size="s"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--s"
+                      />
+                    </EuiSpacer>
+                    <EuiEmptyPrompt
+                      body={
+                        <EuiText>
+                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                        </EuiText>
+                      }
+                      title={
+                        <h2>
+                          No matches
+                        </h2>
+                      }
+                    >
+                      <div
+                        className="euiEmptyPrompt"
+                      >
+                        <EuiTextColor
+                          color="subdued"
+                        >
+                          <span
+                            className="euiTextColor euiTextColor--subdued"
+                          >
+                            <EuiTitle
+                              size="m"
+                            >
+                              <h2
+                                className="euiTitle euiTitle--medium"
+                              >
+                                No matches
+                              </h2>
+                            </EuiTitle>
+                            <EuiSpacer
+                              size="m"
+                            >
+                              <div
+                                className="euiSpacer euiSpacer--m"
+                              />
+                            </EuiSpacer>
+                            <EuiText>
+                              <div
+                                className="euiText euiText--medium"
+                              >
+                                <EuiText>
+                                  <div
+                                    className="euiText euiText--medium"
+                                  >
+                                    No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                  </div>
+                                </EuiText>
+                              </div>
+                            </EuiText>
+                          </span>
+                        </EuiTextColor>
+                      </div>
+                    </EuiEmptyPrompt>
+                    <EuiSpacer
+                      size="s"
+                    >
+                      <div
+                        className="euiSpacer euiSpacer--s"
+                      />
+                    </EuiSpacer>
+                  </NoMatchMessage>
+                </div>
               </div>
             </EuiPanel>
-          </ErrorRatePlt>
+          </ServiceMap>
         </div>
       </EuiFlexItem>
       <EuiFlexItem>
         <div
           className="euiFlexItem"
         >
-          <ThroughputPlt
-            items={
-              Object {
-                "fixedInterval": "1h",
-                "items": Array [],
-              }
-            }
-            setEndTime={[MockFunction]}
-            setStartTime={[MockFunction]}
+          <EuiFlexGroup
+            direction="column"
           >
-            <EuiPanel
-              style={
-                Object {
-                  "minHeight": 308,
-                  "minWidth": 433,
-                }
-              }
+            <div
+              className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionColumn euiFlexGroup--responsive"
             >
-              <div
-                className="euiPanel euiPanel--paddingMedium"
-                style={
-                  Object {
-                    "minHeight": 308,
-                    "minWidth": 433,
-                  }
-                }
-              >
-                <PanelTitle
-                  title="Throughput over time"
+              <EuiFlexItem>
+                <div
+                  className="euiFlexItem"
                 >
-                  <EuiText
-                    size="m"
-                  >
-                    <div
-                      className="euiText euiText--medium"
-                    >
-                      <span
-                        className="panel-title"
-                      >
-                        Throughput over time
-                      </span>
-                    </div>
-                  </EuiText>
-                </PanelTitle>
-                <EuiHorizontalRule
-                  margin="m"
-                >
-                  <hr
-                    className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-                  />
-                </EuiHorizontalRule>
-                <NoMatchMessage
-                  size="s"
-                >
-                  <EuiSpacer
-                    size="s"
-                  >
-                    <div
-                      className="euiSpacer euiSpacer--s"
-                    />
-                  </EuiSpacer>
-                  <EuiEmptyPrompt
-                    body={
-                      <EuiText>
-                        No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                      </EuiText>
+                  <ErrorRatePlt
+                    items={
+                      Object {
+                        "fixedInterval": "1h",
+                        "items": Array [],
+                      }
                     }
-                    title={
-                      <h2>
-                        No matches
-                      </h2>
-                    }
+                    setEndTime={[MockFunction]}
+                    setStartTime={[MockFunction]}
                   >
-                    <div
-                      className="euiEmptyPrompt"
+                    <EuiPanel
+                      style={
+                        Object {
+                          "minHeight": 308,
+                          "minWidth": 433,
+                        }
+                      }
                     >
-                      <EuiTextColor
-                        color="subdued"
+                      <div
+                        className="euiPanel euiPanel--paddingMedium"
+                        style={
+                          Object {
+                            "minHeight": 308,
+                            "minWidth": 433,
+                          }
+                        }
                       >
-                        <span
-                          className="euiTextColor euiTextColor--subdued"
+                        <PanelTitle
+                          title="Error rate over time"
                         >
-                          <EuiTitle
+                          <EuiText
                             size="m"
                           >
-                            <h2
-                              className="euiTitle euiTitle--medium"
-                            >
-                              No matches
-                            </h2>
-                          </EuiTitle>
-                          <EuiSpacer
-                            size="m"
-                          >
-                            <div
-                              className="euiSpacer euiSpacer--m"
-                            />
-                          </EuiSpacer>
-                          <EuiText>
                             <div
                               className="euiText euiText--medium"
                             >
-                              <EuiText>
-                                <div
-                                  className="euiText euiText--medium"
-                                >
-                                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                                </div>
-                              </EuiText>
+                              <span
+                                className="panel-title"
+                              >
+                                Error rate over time
+                              </span>
                             </div>
                           </EuiText>
-                        </span>
-                      </EuiTextColor>
-                    </div>
-                  </EuiEmptyPrompt>
-                  <EuiSpacer
-                    size="s"
+                        </PanelTitle>
+                        <EuiHorizontalRule
+                          margin="m"
+                        >
+                          <hr
+                            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                        </EuiHorizontalRule>
+                        <NoMatchMessage
+                          size="s"
+                        >
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                          <EuiEmptyPrompt
+                            body={
+                              <EuiText>
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </EuiText>
+                            }
+                            title={
+                              <h2>
+                                No matches
+                              </h2>
+                            }
+                          >
+                            <div
+                              className="euiEmptyPrompt"
+                            >
+                              <EuiTextColor
+                                color="subdued"
+                              >
+                                <span
+                                  className="euiTextColor euiTextColor--subdued"
+                                >
+                                  <EuiTitle
+                                    size="m"
+                                  >
+                                    <h2
+                                      className="euiTitle euiTitle--medium"
+                                    >
+                                      No matches
+                                    </h2>
+                                  </EuiTitle>
+                                  <EuiSpacer
+                                    size="m"
+                                  >
+                                    <div
+                                      className="euiSpacer euiSpacer--m"
+                                    />
+                                  </EuiSpacer>
+                                  <EuiText>
+                                    <div
+                                      className="euiText euiText--medium"
+                                    >
+                                      <EuiText>
+                                        <div
+                                          className="euiText euiText--medium"
+                                        >
+                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                        </div>
+                                      </EuiText>
+                                    </div>
+                                  </EuiText>
+                                </span>
+                              </EuiTextColor>
+                            </div>
+                          </EuiEmptyPrompt>
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                        </NoMatchMessage>
+                      </div>
+                    </EuiPanel>
+                  </ErrorRatePlt>
+                </div>
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <div
+                  className="euiFlexItem"
+                >
+                  <ThroughputPlt
+                    items={
+                      Object {
+                        "fixedInterval": "1h",
+                        "items": Array [],
+                      }
+                    }
+                    setEndTime={[MockFunction]}
+                    setStartTime={[MockFunction]}
                   >
-                    <div
-                      className="euiSpacer euiSpacer--s"
-                    />
-                  </EuiSpacer>
-                </NoMatchMessage>
-              </div>
-            </EuiPanel>
-          </ThroughputPlt>
+                    <EuiPanel
+                      style={
+                        Object {
+                          "minHeight": 308,
+                          "minWidth": 433,
+                        }
+                      }
+                    >
+                      <div
+                        className="euiPanel euiPanel--paddingMedium"
+                        style={
+                          Object {
+                            "minHeight": 308,
+                            "minWidth": 433,
+                          }
+                        }
+                      >
+                        <PanelTitle
+                          title="Throughput over time"
+                        >
+                          <EuiText
+                            size="m"
+                          >
+                            <div
+                              className="euiText euiText--medium"
+                            >
+                              <span
+                                className="panel-title"
+                              >
+                                Throughput over time
+                              </span>
+                            </div>
+                          </EuiText>
+                        </PanelTitle>
+                        <EuiHorizontalRule
+                          margin="m"
+                        >
+                          <hr
+                            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
+                          />
+                        </EuiHorizontalRule>
+                        <NoMatchMessage
+                          size="s"
+                        >
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                          <EuiEmptyPrompt
+                            body={
+                              <EuiText>
+                                No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                              </EuiText>
+                            }
+                            title={
+                              <h2>
+                                No matches
+                              </h2>
+                            }
+                          >
+                            <div
+                              className="euiEmptyPrompt"
+                            >
+                              <EuiTextColor
+                                color="subdued"
+                              >
+                                <span
+                                  className="euiTextColor euiTextColor--subdued"
+                                >
+                                  <EuiTitle
+                                    size="m"
+                                  >
+                                    <h2
+                                      className="euiTitle euiTitle--medium"
+                                    >
+                                      No matches
+                                    </h2>
+                                  </EuiTitle>
+                                  <EuiSpacer
+                                    size="m"
+                                  >
+                                    <div
+                                      className="euiSpacer euiSpacer--m"
+                                    />
+                                  </EuiSpacer>
+                                  <EuiText>
+                                    <div
+                                      className="euiText euiText--medium"
+                                    >
+                                      <EuiText>
+                                        <div
+                                          className="euiText euiText--medium"
+                                        >
+                                          No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
+                                        </div>
+                                      </EuiText>
+                                    </div>
+                                  </EuiText>
+                                </span>
+                              </EuiTextColor>
+                            </div>
+                          </EuiEmptyPrompt>
+                          <EuiSpacer
+                            size="s"
+                          >
+                            <div
+                              className="euiSpacer euiSpacer--s"
+                            />
+                          </EuiSpacer>
+                        </NoMatchMessage>
+                      </div>
+                    </EuiPanel>
+                  </ThroughputPlt>
+                </div>
+              </EuiFlexItem>
+            </div>
+          </EuiFlexGroup>
         </div>
       </EuiFlexItem>
     </div>
@@ -1519,7 +2072,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
               isLoading={false}
               onChange={[Function]}
               onSearch={[Function]}
-              placeholder="Trace ID, trace group name"
+              placeholder="Trace ID, trace group name, service name"
               value=""
             >
               <EuiFormControlLayout
@@ -1540,7 +2093,7 @@ exports[`Dashboard component renders empty dashboard 1`] = `
                         data-test-subj="search-bar-input-box"
                         onChange={[Function]}
                         onKeyUp={[Function]}
-                        placeholder="Trace ID, trace group name"
+                        placeholder="Trace ID, trace group name, service name"
                         type="search"
                         value=""
                       />

--- a/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
+++ b/public/components/dashboard/__tests__/__snapshots__/dashboard.test.tsx.snap
@@ -1720,7 +1720,7 @@ exports[`Dashboard component renders dashboard 1`] = `
                         }
                       >
                         <PanelTitle
-                          title="Error rate over time"
+                          title="Trace error rate over time"
                         >
                           <EuiText
                             size="m"
@@ -1731,7 +1731,7 @@ exports[`Dashboard component renders dashboard 1`] = `
                               <span
                                 className="panel-title"
                               >
-                                Error rate over time
+                                Trace error rate over time
                               </span>
                             </div>
                           </EuiText>
@@ -1852,7 +1852,7 @@ exports[`Dashboard component renders dashboard 1`] = `
                         }
                       >
                         <PanelTitle
-                          title="Throughput over time"
+                          title="Traces over time"
                         >
                           <EuiText
                             size="m"
@@ -1863,7 +1863,7 @@ exports[`Dashboard component renders dashboard 1`] = `
                               <span
                                 className="panel-title"
                               >
-                                Throughput over time
+                                Traces over time
                               </span>
                             </div>
                           </EuiText>

--- a/public/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
+++ b/public/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
     Array [
       Object {
         "disabled": false,
-        "field": "traceGroup",
+        "field": "traceGroup.name",
         "inverted": false,
         "operator": "exists",
         "value": "exists",

--- a/public/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
+++ b/public/components/dashboard/__tests__/__snapshots__/dashboard_table.test.tsx.snap
@@ -331,7 +331,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                   <EuiText
                     size="xs"
                   >
-                    Error rate based on count of errors on all traces and spans within a trace group in the selected time range (eg. 3 errors on different spans on a single trace counts as 3 errors in this calculation).
+                    Error rate based on count of trace errors within a trace group in the selected time range.
                   </EuiText>
                 }
                 delay="regular"
@@ -577,7 +577,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                     <EuiText
                       size="xs"
                     >
-                      Error rate based on count of errors on all traces and spans within a trace group in the selected time range (eg. 3 errors on different spans on a single trace counts as 3 errors in this calculation).
+                      Error rate based on count of trace errors within a trace group in the selected time range.
                     </EuiText>
                   }
                   delay="regular"
@@ -852,7 +852,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                       <EuiText
                                         size="xs"
                                       >
-                                        Error rate based on count of errors on all traces and spans within a trace group in the selected time range (eg. 3 errors on different spans on a single trace counts as 3 errors in this calculation).
+                                        Error rate based on count of trace errors within a trace group in the selected time range.
                                       </EuiText>
                                     }
                                     delay="regular"
@@ -1590,7 +1590,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                           <EuiText
                                             size="xs"
                                           >
-                                            Error rate based on count of errors on all traces and spans within a trace group in the selected time range (eg. 3 errors on different spans on a single trace counts as 3 errors in this calculation).
+                                            Error rate based on count of trace errors within a trace group in the selected time range.
                                           </EuiText>
                                         }
                                         delay="regular"
@@ -2580,7 +2580,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                     <EuiText
                                       size="xs"
                                     >
-                                      Error rate based on count of errors on all traces and spans within a trace group in the selected time range (eg. 3 errors on different spans on a single trace counts as 3 errors in this calculation).
+                                      Error rate based on count of trace errors within a trace group in the selected time range.
                                     </EuiText>
                                   }
                                   delay="regular"
@@ -2624,7 +2624,7 @@ exports[`Dashboard table component renders dashboard table 1`] = `
                                     <EuiText
                                       size="xs"
                                     >
-                                      Error rate based on count of errors on all traces and spans within a trace group in the selected time range (eg. 3 errors on different spans on a single trace counts as 3 errors in this calculation).
+                                      Error rate based on count of trace errors within a trace group in the selected time range.
                                     </EuiText>
                                   }
                                   delay="regular"

--- a/public/components/dashboard/__tests__/dashboard_table.test.tsx
+++ b/public/components/dashboard/__tests__/dashboard_table.test.tsx
@@ -58,7 +58,7 @@ describe('Dashboard table component', () => {
         items={tableItems}
         filters={[
           {
-            field: 'traceGroup',
+            field: 'traceGroup.name',
             operator: 'exists',
             value: 'exists',
             inverted: false,

--- a/public/components/dashboard/dashboard.tsx
+++ b/public/components/dashboard/dashboard.tsx
@@ -179,6 +179,7 @@ export function Dashboard(props: DashboardProps) {
           <EuiFlexGroup alignItems="baseline">
             <EuiFlexItem grow={4}>
               <ServiceMap
+                addFilter={addFilter}
                 serviceMap={serviceMap}
                 idSelected={serviceMapIdSelected}
                 setIdSelected={setServiceMapIdSelected}

--- a/public/components/dashboard/dashboard.tsx
+++ b/public/components/dashboard/dashboard.tsx
@@ -14,7 +14,6 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
-import _ from 'lodash';
 import React, { useEffect, useState } from 'react';
 import {
   handleDashboardErrorRatePltRequest,
@@ -178,19 +177,30 @@ export function Dashboard(props: DashboardProps) {
           />
           <EuiSpacer />
           <EuiFlexGroup alignItems="baseline">
-            <EuiFlexItem>
-              <ErrorRatePlt
-                items={errorRatePltItems}
-                setStartTime={props.setStartTime}
-                setEndTime={props.setEndTime}
+            <EuiFlexItem grow={4}>
+              <ServiceMap
+                serviceMap={serviceMap}
+                idSelected={serviceMapIdSelected}
+                setIdSelected={setServiceMapIdSelected}
               />
             </EuiFlexItem>
             <EuiFlexItem>
-              <ThroughputPlt
-                items={throughputPltItems}
-                setStartTime={props.setStartTime}
-                setEndTime={props.setEndTime}
-              />
+              <EuiFlexGroup direction="column">
+                <EuiFlexItem>
+                  <ErrorRatePlt
+                    items={errorRatePltItems}
+                    setStartTime={props.setStartTime}
+                    setEndTime={props.setEndTime}
+                  />
+                </EuiFlexItem>
+                <EuiFlexItem>
+                  <ThroughputPlt
+                    items={throughputPltItems}
+                    setStartTime={props.setStartTime}
+                    setEndTime={props.setEndTime}
+                  />
+                </EuiFlexItem>
+              </EuiFlexGroup>
             </EuiFlexItem>
           </EuiFlexGroup>
         </>

--- a/public/components/dashboard/dashboard_table.tsx
+++ b/public/components/dashboard/dashboard_table.tsx
@@ -23,17 +23,17 @@ import {
   EuiLink,
   EuiPanel,
   EuiSpacer,
+  EuiTableFieldDataColumnType,
   EuiText,
   EuiToolTip,
   PropertySort,
 } from '@elastic/eui';
-import React, { useMemo, useState } from 'react';
 import _ from 'lodash';
-import { EuiTableFieldDataColumnType } from '@elastic/eui';
-import { calculateTicks, NoMatchMessage, PanelTitle, renderBenchmark } from '../common';
+import React, { useMemo, useState } from 'react';
+import { calculateTicks, NoMatchMessage, PanelTitle } from '../common';
+import { FilterType } from '../common/filters/filters';
 import { BoxPlt } from '../common/plots/box_plt';
 import { LatencyTrendCell } from './latency_trend_cell';
-import { FilterType } from '../common/filters/filters';
 
 export function DashboardTable(props: {
   items: any[];
@@ -275,9 +275,8 @@ export function DashboardTable(props: {
           <EuiToolTip
             content={
               <EuiText size="xs">
-                Error rate based on count of errors on all traces and spans within a trace group in
-                the selected time range (eg. 3 errors on different spans on a single trace counts as
-                3 errors in this calculation).
+                Error rate based on count of trace errors within a trace group in the selected time
+                range.
               </EuiText>
             }
           >

--- a/public/components/dashboard/dashboard_table.tsx
+++ b/public/components/dashboard/dashboard_table.tsx
@@ -111,7 +111,7 @@ export function DashboardTable(props: {
               data-test-subj="dashboard-table-trace-group-name-button"
               onClick={() =>
                 props.addFilter({
-                  field: 'traceGroup',
+                  field: 'traceGroup.name',
                   operator: 'is',
                   value: item,
                   inverted: false,
@@ -179,7 +179,7 @@ export function DashboardTable(props: {
                 currPercentileFilter,
                 addFilter: (condition?: 'lte' | 'gte') => {
                   const traceGroupFilter = {
-                    field: 'traceGroup',
+                    field: 'traceGroup.name',
                     operator: 'is',
                     value: row.dashboard_trace_group_name,
                     inverted: false,
@@ -332,7 +332,7 @@ export function DashboardTable(props: {
             onClick={() => {
               props.setRedirect(true);
               props.addFilter({
-                field: 'traceGroup',
+                field: 'traceGroup.name',
                 operator: 'is',
                 value: row.dashboard_trace_group_name,
                 inverted: false,

--- a/public/components/services/__tests__/__snapshots__/services.test.tsx.snap
+++ b/public/components/services/__tests__/__snapshots__/services.test.tsx.snap
@@ -67,7 +67,6 @@ exports[`Services component renders empty services page 1`] = `
     </h2>
   </EuiTitle>
   <SearchBar
-    datepickerOnly={true}
     endTime="now"
     filters={Array []}
     page="services"
@@ -99,6 +98,93 @@ exports[`Services component renders empty services page 1`] = `
       <div
         className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
       >
+        <EuiFlexItem>
+          <div
+            className="euiFlexItem"
+          >
+            <EuiFieldSearch
+              compressed={false}
+              data-test-subj="search-bar-input-box"
+              fullWidth={true}
+              incremental={false}
+              isClearable={false}
+              isLoading={false}
+              onChange={[Function]}
+              onSearch={[Function]}
+              placeholder="Trace ID, trace group name, service name"
+              value=""
+            >
+              <EuiFormControlLayout
+                compressed={false}
+                fullWidth={true}
+                icon="search"
+                isLoading={false}
+              >
+                <div
+                  className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl>
+                      <input
+                        className="euiFieldSearch euiFieldSearch--fullWidth"
+                        data-test-subj="search-bar-input-box"
+                        onChange={[Function]}
+                        onKeyUp={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        type="search"
+                        value=""
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons
+                      icon="search"
+                      isLoading={false}
+                    >
+                      <div
+                        className="euiFormControlLayoutIcons"
+                      >
+                        <EuiFormControlLayoutCustomIcon
+                          type="search"
+                        >
+                          <span
+                            className="euiFormControlLayoutCustomIcon"
+                          >
+                            <EuiIcon
+                              aria-hidden="true"
+                              className="euiFormControlLayoutCustomIcon__icon"
+                              type="search"
+                            >
+                              <EuiIconEmpty
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                />
+                              </EuiIconEmpty>
+                            </EuiIcon>
+                          </span>
+                        </EuiFormControlLayoutCustomIcon>
+                      </div>
+                    </EuiFormControlLayoutIcons>
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldSearch>
+          </div>
+        </EuiFlexItem>
         <EuiFlexItem
           grow={false}
         >
@@ -565,162 +651,446 @@ exports[`Services component renders empty services page 1`] = `
         </EuiFlexItem>
       </div>
     </EuiFlexGroup>
+    <EuiSpacer
+      size="s"
+    >
+      <div
+        className="euiSpacer euiSpacer--s"
+      />
+    </EuiSpacer>
+    <Filters
+      filters={Array []}
+      page="services"
+      setFilters={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Array [],
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+    >
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+          }
+        }
+      >
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+          style={
+            Object {
+              "minHeight": 32,
+            }
+          }
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <GlobalFilterButton>
+                <EuiPopover
+                  anchorPosition="rightUp"
+                  button={
+                    <EuiButtonIcon
+                      aria-label="Change all filters"
+                      iconType="filter"
+                      onClick={[Function]}
+                      title="Change all filters"
+                    />
+                  }
+                  closePopover={[Function]}
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={false}
+                  panelPaddingSize="none"
+                  withTitle={true}
+                >
+                  <EuiOutsideClickDetector
+                    isDisabled={true}
+                    onOutsideClick={[Function]}
+                  >
+                    <div
+                      className="euiPopover euiPopover--anchorRightUp euiPopover--withTitle"
+                      onKeyDown={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        className="euiPopover__anchor"
+                      >
+                        <EuiButtonIcon
+                          aria-label="Change all filters"
+                          iconType="filter"
+                          onClick={[Function]}
+                          title="Change all filters"
+                        >
+                          <button
+                            aria-label="Change all filters"
+                            className="euiButtonIcon euiButtonIcon--primary"
+                            disabled={false}
+                            onClick={[Function]}
+                            title="Change all filters"
+                            type="button"
+                          >
+                            <EuiIcon
+                              aria-hidden="true"
+                              className="euiButtonIcon__icon"
+                              size="m"
+                              type="filter"
+                            >
+                              <EuiIconEmpty
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonIcon__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                />
+                              </EuiIconEmpty>
+                            </EuiIcon>
+                          </button>
+                        </EuiButtonIcon>
+                      </div>
+                    </div>
+                  </EuiOutsideClickDetector>
+                </EuiPopover>
+              </GlobalFilterButton>
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={false}
+                  panelPaddingSize="m"
+                  withTitle={true}
+                >
+                  <EuiOutsideClickDetector
+                    isDisabled={true}
+                    onOutsideClick={[Function]}
+                  >
+                    <div
+                      className="euiPopover euiPopover--anchorDownLeft euiPopover--withTitle"
+                      onKeyDown={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        className="euiPopover__anchor"
+                      >
+                        <EuiButtonEmpty
+                          onClick={[Function]}
+                          size="xs"
+                        >
+                          <button
+                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <EuiButtonContent
+                              className="euiButtonEmpty__content"
+                              iconSide="left"
+                              textProps={
+                                Object {
+                                  "className": "euiButtonEmpty__text",
+                                }
+                              }
+                            >
+                              <span
+                                className="euiButtonContent euiButtonEmpty__content"
+                              >
+                                <span
+                                  className="euiButtonEmpty__text"
+                                >
+                                  + Add filter
+                                </span>
+                              </span>
+                            </EuiButtonContent>
+                          </button>
+                        </EuiButtonEmpty>
+                      </div>
+                    </div>
+                  </EuiOutsideClickDetector>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
   </SearchBar>
   <EuiSpacer>
     <div
       className="euiSpacer euiSpacer--l"
     />
   </EuiSpacer>
-  <MissingConfigurationMessage>
-    <EuiEmptyPrompt
-      actions={
-        <EuiButton
-          color="primary"
-          iconSide="right"
-          iconType="popout"
-          onClick={[Function]}
-        >
-          Learn more
-        </EuiButton>
-      }
-      body={
-        <EuiText>
-          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-        </EuiText>
-      }
-      title={
-        <h2>
-          Trace Analytics not set up
-        </h2>
-      }
-    >
+  <ServicesTable
+    addFilter={[Function]}
+    indicesExist={false}
+    items={Array []}
+    refresh={[Function]}
+    serviceQuery=""
+    setRedirect={[Function]}
+    setServiceQuery={[Function]}
+  >
+    <EuiPanel>
       <div
-        className="euiEmptyPrompt"
+        className="euiPanel euiPanel--paddingMedium"
       >
-        <EuiTextColor
-          color="subdued"
+        <EuiFlexGroup
+          alignItems="center"
+          gutterSize="s"
         >
-          <span
-            className="euiTextColor euiTextColor--subdued"
+          <div
+            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
           >
-            <EuiTitle
-              size="m"
-            >
-              <h2
-                className="euiTitle euiTitle--medium"
-              >
-                Trace Analytics not set up
-              </h2>
-            </EuiTitle>
-            <EuiSpacer
-              size="m"
+            <EuiFlexItem
+              grow={10}
             >
               <div
-                className="euiSpacer euiSpacer--m"
-              />
-            </EuiSpacer>
-            <EuiText>
-              <div
-                className="euiText euiText--medium"
+                className="euiFlexItem euiFlexItem--flexGrow10"
               >
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
+                <PanelTitle
+                  title="Services"
+                  totalItems={0}
+                >
+                  <EuiText
+                    size="m"
                   >
-                    The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
-                  </div>
-                </EuiText>
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <span
+                        className="panel-title"
+                      >
+                        Services
+                      </span>
+                      <span
+                        className="panel-title-count"
+                      >
+                         (0)
+                      </span>
+                    </div>
+                  </EuiText>
+                </PanelTitle>
               </div>
-            </EuiText>
-          </span>
-        </EuiTextColor>
+            </EuiFlexItem>
+          </div>
+        </EuiFlexGroup>
         <EuiSpacer
-          size="l"
+          size="m"
         >
           <div
-            className="euiSpacer euiSpacer--l"
+            className="euiSpacer euiSpacer--m"
           />
         </EuiSpacer>
-        <EuiSpacer
-          size="s"
+        <EuiHorizontalRule
+          margin="none"
         >
-          <div
-            className="euiSpacer euiSpacer--s"
+          <hr
+            className="euiHorizontalRule euiHorizontalRule--full"
           />
-        </EuiSpacer>
-        <EuiButton
-          color="primary"
-          iconSide="right"
-          iconType="popout"
-          onClick={[Function]}
-        >
-          <EuiButtonDisplay
-            color="primary"
-            disabled={false}
-            element="button"
-            iconSide="right"
-            iconType="popout"
-            isDisabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <button
-              className="euiButton euiButton--primary"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <EuiButtonContent
-                className="euiButton__content"
+        </EuiHorizontalRule>
+        <MissingConfigurationMessage>
+          <EuiEmptyPrompt
+            actions={
+              <EuiButton
+                color="primary"
                 iconSide="right"
                 iconType="popout"
-                textProps={
-                  Object {
-                    "className": "euiButton__text",
-                  }
-                }
+                onClick={[Function]}
+              >
+                Learn more
+              </EuiButton>
+            }
+            body={
+              <EuiText>
+                The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+              </EuiText>
+            }
+            title={
+              <h2>
+                Trace Analytics not set up
+              </h2>
+            }
+          >
+            <div
+              className="euiEmptyPrompt"
+            >
+              <EuiTextColor
+                color="subdued"
               >
                 <span
-                  className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                  className="euiTextColor euiTextColor--subdued"
                 >
-                  <EuiIcon
-                    className="euiButtonContent__icon"
+                  <EuiTitle
                     size="m"
-                    type="popout"
                   >
-                    <EuiIconEmpty
-                      aria-hidden={true}
-                      className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
-                      focusable="false"
-                      role="img"
-                      style={null}
+                    <h2
+                      className="euiTitle euiTitle--medium"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
-                        focusable="false"
-                        height={16}
-                        role="img"
-                        style={null}
-                        viewBox="0 0 16 16"
-                        width={16}
-                        xmlns="http://www.w3.org/2000/svg"
-                      />
-                    </EuiIconEmpty>
-                  </EuiIcon>
-                  <span
-                    className="euiButton__text"
+                      Trace Analytics not set up
+                    </h2>
+                  </EuiTitle>
+                  <EuiSpacer
+                    size="m"
                   >
-                    Learn more
-                  </span>
+                    <div
+                      className="euiSpacer euiSpacer--m"
+                    />
+                  </EuiSpacer>
+                  <EuiText>
+                    <div
+                      className="euiText euiText--medium"
+                    >
+                      <EuiText>
+                        <div
+                          className="euiText euiText--medium"
+                        >
+                          The indices required for trace analytics (otel-v1-apm-span-* and otel-v1-apm-service-map*) do not exist or you do not have permission to access them.
+                        </div>
+                      </EuiText>
+                    </div>
+                  </EuiText>
                 </span>
-              </EuiButtonContent>
-            </button>
-          </EuiButtonDisplay>
-        </EuiButton>
+              </EuiTextColor>
+              <EuiSpacer
+                size="l"
+              >
+                <div
+                  className="euiSpacer euiSpacer--l"
+                />
+              </EuiSpacer>
+              <EuiSpacer
+                size="s"
+              >
+                <div
+                  className="euiSpacer euiSpacer--s"
+                />
+              </EuiSpacer>
+              <EuiButton
+                color="primary"
+                iconSide="right"
+                iconType="popout"
+                onClick={[Function]}
+              >
+                <EuiButtonDisplay
+                  color="primary"
+                  disabled={false}
+                  element="button"
+                  iconSide="right"
+                  iconType="popout"
+                  isDisabled={false}
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <button
+                    className="euiButton euiButton--primary"
+                    disabled={false}
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <EuiButtonContent
+                      className="euiButton__content"
+                      iconSide="right"
+                      iconType="popout"
+                      textProps={
+                        Object {
+                          "className": "euiButton__text",
+                        }
+                      }
+                    >
+                      <span
+                        className="euiButtonContent euiButtonContent--iconRight euiButton__content"
+                      >
+                        <EuiIcon
+                          className="euiButtonContent__icon"
+                          size="m"
+                          type="popout"
+                        >
+                          <EuiIconEmpty
+                            aria-hidden={true}
+                            className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
+                            focusable="false"
+                            role="img"
+                            style={null}
+                          >
+                            <svg
+                              aria-hidden={true}
+                              className="euiIcon euiIcon--medium euiIcon-isLoading euiButtonContent__icon"
+                              focusable="false"
+                              height={16}
+                              role="img"
+                              style={null}
+                              viewBox="0 0 16 16"
+                              width={16}
+                              xmlns="http://www.w3.org/2000/svg"
+                            />
+                          </EuiIconEmpty>
+                        </EuiIcon>
+                        <span
+                          className="euiButton__text"
+                        >
+                          Learn more
+                        </span>
+                      </span>
+                    </EuiButtonContent>
+                  </button>
+                </EuiButtonDisplay>
+              </EuiButton>
+            </div>
+          </EuiEmptyPrompt>
+        </MissingConfigurationMessage>
       </div>
-    </EuiEmptyPrompt>
-  </MissingConfigurationMessage>
+    </EuiPanel>
+  </ServicesTable>
 </Services>
 `;
 
@@ -791,7 +1161,6 @@ exports[`Services component renders services page 1`] = `
     </h2>
   </EuiTitle>
   <SearchBar
-    datepickerOnly={true}
     endTime="now"
     filters={Array []}
     page="services"
@@ -823,6 +1192,97 @@ exports[`Services component renders services page 1`] = `
       <div
         className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--directionRow euiFlexGroup--responsive"
       >
+        <EuiFlexItem>
+          <div
+            className="euiFlexItem"
+          >
+            <EuiFieldSearch
+              compressed={false}
+              data-test-subj="search-bar-input-box"
+              fullWidth={true}
+              incremental={false}
+              isClearable={false}
+              isLoading={false}
+              onChange={[Function]}
+              onSearch={[Function]}
+              placeholder="Trace ID, trace group name, service name"
+              value=""
+            >
+              <EuiFormControlLayout
+                compressed={false}
+                fullWidth={true}
+                icon="search"
+                isLoading={false}
+              >
+                <div
+                  className="euiFormControlLayout euiFormControlLayout--fullWidth"
+                >
+                  <div
+                    className="euiFormControlLayout__childrenWrapper"
+                  >
+                    <EuiValidatableControl>
+                      <input
+                        className="euiFieldSearch euiFieldSearch--fullWidth"
+                        data-test-subj="search-bar-input-box"
+                        onChange={[Function]}
+                        onKeyUp={[Function]}
+                        placeholder="Trace ID, trace group name, service name"
+                        type="search"
+                        value=""
+                      />
+                    </EuiValidatableControl>
+                    <EuiFormControlLayoutIcons
+                      icon="search"
+                      isLoading={false}
+                    >
+                      <div
+                        className="euiFormControlLayoutIcons"
+                      >
+                        <EuiFormControlLayoutCustomIcon
+                          type="search"
+                        >
+                          <span
+                            className="euiFormControlLayoutCustomIcon"
+                          >
+                            <EuiIcon
+                              aria-hidden="true"
+                              className="euiFormControlLayoutCustomIcon__icon"
+                              type="search"
+                            >
+                              <EuiIconSearch
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
+                                  />
+                                </svg>
+                              </EuiIconSearch>
+                            </EuiIcon>
+                          </span>
+                        </EuiFormControlLayoutCustomIcon>
+                      </div>
+                    </EuiFormControlLayoutIcons>
+                  </div>
+                </div>
+              </EuiFormControlLayout>
+            </EuiFieldSearch>
+          </div>
+        </EuiFlexItem>
         <EuiFlexItem
           grow={false}
         >
@@ -1303,6 +1763,225 @@ exports[`Services component renders services page 1`] = `
         </EuiFlexItem>
       </div>
     </EuiFlexGroup>
+    <EuiSpacer
+      size="s"
+    >
+      <div
+        className="euiSpacer euiSpacer--s"
+      />
+    </EuiSpacer>
+    <Filters
+      filters={Array []}
+      page="services"
+      setFilters={
+        [MockFunction] {
+          "calls": Array [
+            Array [
+              Array [],
+            ],
+          ],
+          "results": Array [
+            Object {
+              "type": "return",
+              "value": undefined,
+            },
+          ],
+        }
+      }
+    >
+      <EuiFlexGroup
+        alignItems="center"
+        gutterSize="xs"
+        responsive={false}
+        style={
+          Object {
+            "minHeight": 32,
+          }
+        }
+      >
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterExtraSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow"
+          style={
+            Object {
+              "minHeight": 32,
+            }
+          }
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <GlobalFilterButton>
+                <EuiPopover
+                  anchorPosition="rightUp"
+                  button={
+                    <EuiButtonIcon
+                      aria-label="Change all filters"
+                      iconType="filter"
+                      onClick={[Function]}
+                      title="Change all filters"
+                    />
+                  }
+                  closePopover={[Function]}
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={false}
+                  panelPaddingSize="none"
+                  withTitle={true}
+                >
+                  <EuiOutsideClickDetector
+                    isDisabled={true}
+                    onOutsideClick={[Function]}
+                  >
+                    <div
+                      className="euiPopover euiPopover--anchorRightUp euiPopover--withTitle"
+                      onKeyDown={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        className="euiPopover__anchor"
+                      >
+                        <EuiButtonIcon
+                          aria-label="Change all filters"
+                          iconType="filter"
+                          onClick={[Function]}
+                          title="Change all filters"
+                        >
+                          <button
+                            aria-label="Change all filters"
+                            className="euiButtonIcon euiButtonIcon--primary"
+                            disabled={false}
+                            onClick={[Function]}
+                            title="Change all filters"
+                            type="button"
+                          >
+                            <EuiIcon
+                              aria-hidden="true"
+                              className="euiButtonIcon__icon"
+                              size="m"
+                              type="filter"
+                            >
+                              <EuiIconFilter
+                                aria-hidden={true}
+                                className="euiIcon euiIcon--medium euiButtonIcon__icon"
+                                focusable="false"
+                                role="img"
+                                style={null}
+                              >
+                                <svg
+                                  aria-hidden={true}
+                                  className="euiIcon euiIcon--medium euiButtonIcon__icon"
+                                  focusable="false"
+                                  height={16}
+                                  role="img"
+                                  style={null}
+                                  viewBox="0 0 16 16"
+                                  width={16}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M7.999 15.999a8 8 0 110-16 8 8 0 010 16zM8 15A7 7 0 108 1a7 7 0 000 14zM3.5 5h9a.5.5 0 110 1h-9a.5.5 0 010-1zm2 3h5a.5.5 0 110 1h-5a.5.5 0 010-1zm2 3h1a.5.5 0 110 1h-1a.5.5 0 110-1z"
+                                    fillRule="evenodd"
+                                  />
+                                </svg>
+                              </EuiIconFilter>
+                            </EuiIcon>
+                          </button>
+                        </EuiButtonIcon>
+                      </div>
+                    </div>
+                  </EuiOutsideClickDetector>
+                </EuiPopover>
+              </GlobalFilterButton>
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <AddFilterButton>
+                <EuiPopover
+                  anchorPosition="downLeft"
+                  button={
+                    <EuiButtonEmpty
+                      onClick={[Function]}
+                      size="xs"
+                    >
+                      + Add filter
+                    </EuiButtonEmpty>
+                  }
+                  closePopover={[Function]}
+                  display="inlineBlock"
+                  hasArrow={true}
+                  isOpen={false}
+                  ownFocus={false}
+                  panelPaddingSize="m"
+                  withTitle={true}
+                >
+                  <EuiOutsideClickDetector
+                    isDisabled={true}
+                    onOutsideClick={[Function]}
+                  >
+                    <div
+                      className="euiPopover euiPopover--anchorDownLeft euiPopover--withTitle"
+                      onKeyDown={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchStart={[Function]}
+                    >
+                      <div
+                        className="euiPopover__anchor"
+                      >
+                        <EuiButtonEmpty
+                          onClick={[Function]}
+                          size="xs"
+                        >
+                          <button
+                            className="euiButtonEmpty euiButtonEmpty--primary euiButtonEmpty--xSmall"
+                            disabled={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <EuiButtonContent
+                              className="euiButtonEmpty__content"
+                              iconSide="left"
+                              textProps={
+                                Object {
+                                  "className": "euiButtonEmpty__text",
+                                }
+                              }
+                            >
+                              <span
+                                className="euiButtonContent euiButtonEmpty__content"
+                              >
+                                <span
+                                  className="euiButtonEmpty__text"
+                                >
+                                  + Add filter
+                                </span>
+                              </span>
+                            </EuiButtonContent>
+                          </button>
+                        </EuiButtonEmpty>
+                      </div>
+                    </div>
+                  </EuiOutsideClickDetector>
+                </EuiPopover>
+              </AddFilterButton>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
+    </Filters>
   </SearchBar>
   <EuiSpacer>
     <div
@@ -1311,6 +1990,7 @@ exports[`Services component renders services page 1`] = `
   </EuiSpacer>
   <ServicesTable
     addFilter={[Function]}
+    indicesExist={true}
     items={Array []}
     refresh={[Function]}
     serviceQuery=""
@@ -1361,117 +2041,18 @@ exports[`Services component renders services page 1`] = `
             </EuiFlexItem>
           </div>
         </EuiFlexGroup>
-        <EuiHorizontalRule
-          margin="s"
-          style={
-            Object {
-              "marginTop": 10,
-            }
-          }
+        <EuiSpacer
+          size="m"
         >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-            style={
-              Object {
-                "marginTop": 10,
-              }
-            }
+          <div
+            className="euiSpacer euiSpacer--m"
           />
-        </EuiHorizontalRule>
-        <EuiFieldSearch
-          compressed={false}
-          fullWidth={true}
-          incremental={false}
-          isClearable={true}
-          isLoading={false}
-          onChange={[Function]}
-          onSearch={[Function]}
-          placeholder="Service name"
-          value=""
-        >
-          <EuiFormControlLayout
-            compressed={false}
-            fullWidth={true}
-            icon="search"
-            isLoading={false}
-          >
-            <div
-              className="euiFormControlLayout euiFormControlLayout--fullWidth"
-            >
-              <div
-                className="euiFormControlLayout__childrenWrapper"
-              >
-                <EuiValidatableControl>
-                  <input
-                    className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
-                    onChange={[Function]}
-                    onKeyUp={[Function]}
-                    placeholder="Service name"
-                    type="search"
-                    value=""
-                  />
-                </EuiValidatableControl>
-                <EuiFormControlLayoutIcons
-                  icon="search"
-                  isLoading={false}
-                >
-                  <div
-                    className="euiFormControlLayoutIcons"
-                  >
-                    <EuiFormControlLayoutCustomIcon
-                      type="search"
-                    >
-                      <span
-                        className="euiFormControlLayoutCustomIcon"
-                      >
-                        <EuiIcon
-                          aria-hidden="true"
-                          className="euiFormControlLayoutCustomIcon__icon"
-                          type="search"
-                        >
-                          <EuiIconEmpty
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            />
-                          </EuiIconEmpty>
-                        </EuiIcon>
-                      </span>
-                    </EuiFormControlLayoutCustomIcon>
-                  </div>
-                </EuiFormControlLayoutIcons>
-              </div>
-            </div>
-          </EuiFormControlLayout>
-        </EuiFieldSearch>
+        </EuiSpacer>
         <EuiHorizontalRule
-          margin="s"
-          style={
-            Object {
-              "marginBottom": 0,
-            }
-          }
+          margin="none"
         >
           <hr
-            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-            style={
-              Object {
-                "marginBottom": 0,
-              }
-            }
+            className="euiHorizontalRule euiHorizontalRule--full"
           />
         </EuiHorizontalRule>
         <NoMatchMessage
@@ -1549,536 +2130,5 @@ exports[`Services component renders services page 1`] = `
       </div>
     </EuiPanel>
   </ServicesTable>
-  <EuiSpacer>
-    <div
-      className="euiSpacer euiSpacer--l"
-    />
-  </EuiSpacer>
-  <ServiceMap
-    idSelected="latency"
-    serviceMap={Object {}}
-    setIdSelected={[Function]}
-  >
-    <EuiPanel>
-      <div
-        className="euiPanel euiPanel--paddingMedium"
-      >
-        <PanelTitle
-          title="Service map"
-        >
-          <EuiText
-            size="m"
-          >
-            <div
-              className="euiText euiText--medium"
-            >
-              <span
-                className="panel-title"
-              >
-                Service map
-              </span>
-            </div>
-          </EuiText>
-        </PanelTitle>
-        <EuiSpacer
-          size="m"
-        >
-          <div
-            className="euiSpacer euiSpacer--m"
-          />
-        </EuiSpacer>
-        <EuiButtonGroup
-          buttonSize="s"
-          color="text"
-          idSelected="latency"
-          onChange={[Function]}
-          options={
-            Array [
-              Object {
-                "id": "latency",
-                "label": "Latency",
-              },
-              Object {
-                "id": "error_rate",
-                "label": "Error rate",
-              },
-              Object {
-                "id": "throughput",
-                "label": "Throughput",
-              },
-            ]
-          }
-        >
-          <fieldset
-            className="euiButtonGroup__fieldset"
-          >
-            <div
-              className="euiButtonGroup euiButtonGroup--s"
-            >
-              <EuiButtonToggle
-                className="euiButtonGroup__button euiButtonGroup__button--selected"
-                color="text"
-                fill={true}
-                id="latency"
-                isSelected={true}
-                key="0"
-                label="Latency"
-                onChange={[Function]}
-                size="s"
-                toggleClassName="euiButtonGroup__toggle"
-                type="single"
-              >
-                <EuiToggle
-                  checked={true}
-                  className="euiButtonToggle__wrapper euiButtonGroup__toggle"
-                  inputClassName="euiButtonToggle__input"
-                  label="Latency"
-                  onChange={[Function]}
-                  title="Latency"
-                  type="single"
-                >
-                  <div
-                    className="euiToggle euiToggle--checked euiButtonToggle__wrapper euiButtonGroup__toggle"
-                  >
-                    <input
-                      aria-label="Latency"
-                      checked={true}
-                      className="euiToggle__input euiButtonToggle__input"
-                      onChange={[Function]}
-                      title="Latency"
-                      type="radio"
-                    />
-                    <EuiButton
-                      className="euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected"
-                      color="text"
-                      fill={true}
-                      id="latency"
-                      size="s"
-                      tabIndex={-1}
-                    >
-                      <EuiButtonDisplay
-                        className="euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected"
-                        color="text"
-                        disabled={false}
-                        element="button"
-                        fill={true}
-                        id="latency"
-                        isDisabled={false}
-                        size="s"
-                        tabIndex={-1}
-                        type="button"
-                      >
-                        <button
-                          className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
-                          disabled={false}
-                          id="latency"
-                          tabIndex={-1}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
-                            textProps={
-                              Object {
-                                "className": "euiButton__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButton__content"
-                            >
-                              <span
-                                className="euiButton__text"
-                              >
-                                Latency
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonDisplay>
-                    </EuiButton>
-                  </div>
-                </EuiToggle>
-              </EuiButtonToggle>
-              <EuiButtonToggle
-                className="euiButtonGroup__button"
-                color="text"
-                fill={false}
-                id="error_rate"
-                isSelected={false}
-                key="1"
-                label="Error rate"
-                onChange={[Function]}
-                size="s"
-                toggleClassName="euiButtonGroup__toggle"
-                type="single"
-              >
-                <EuiToggle
-                  checked={false}
-                  className="euiButtonToggle__wrapper euiButtonGroup__toggle"
-                  inputClassName="euiButtonToggle__input"
-                  label="Error rate"
-                  onChange={[Function]}
-                  title="Error rate"
-                  type="single"
-                >
-                  <div
-                    className="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
-                  >
-                    <input
-                      aria-label="Error rate"
-                      checked={false}
-                      className="euiToggle__input euiButtonToggle__input"
-                      onChange={[Function]}
-                      title="Error rate"
-                      type="radio"
-                    />
-                    <EuiButton
-                      className="euiButtonToggle euiButtonGroup__button"
-                      color="text"
-                      fill={false}
-                      id="error_rate"
-                      size="s"
-                      tabIndex={-1}
-                    >
-                      <EuiButtonDisplay
-                        className="euiButtonToggle euiButtonGroup__button"
-                        color="text"
-                        disabled={false}
-                        element="button"
-                        fill={false}
-                        id="error_rate"
-                        isDisabled={false}
-                        size="s"
-                        tabIndex={-1}
-                        type="button"
-                      >
-                        <button
-                          className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
-                          disabled={false}
-                          id="error_rate"
-                          tabIndex={-1}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
-                            textProps={
-                              Object {
-                                "className": "euiButton__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButton__content"
-                            >
-                              <span
-                                className="euiButton__text"
-                              >
-                                Error rate
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonDisplay>
-                    </EuiButton>
-                  </div>
-                </EuiToggle>
-              </EuiButtonToggle>
-              <EuiButtonToggle
-                className="euiButtonGroup__button"
-                color="text"
-                fill={false}
-                id="throughput"
-                isSelected={false}
-                key="2"
-                label="Throughput"
-                onChange={[Function]}
-                size="s"
-                toggleClassName="euiButtonGroup__toggle"
-                type="single"
-              >
-                <EuiToggle
-                  checked={false}
-                  className="euiButtonToggle__wrapper euiButtonGroup__toggle"
-                  inputClassName="euiButtonToggle__input"
-                  label="Throughput"
-                  onChange={[Function]}
-                  title="Throughput"
-                  type="single"
-                >
-                  <div
-                    className="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
-                  >
-                    <input
-                      aria-label="Throughput"
-                      checked={false}
-                      className="euiToggle__input euiButtonToggle__input"
-                      onChange={[Function]}
-                      title="Throughput"
-                      type="radio"
-                    />
-                    <EuiButton
-                      className="euiButtonToggle euiButtonGroup__button"
-                      color="text"
-                      fill={false}
-                      id="throughput"
-                      size="s"
-                      tabIndex={-1}
-                    >
-                      <EuiButtonDisplay
-                        className="euiButtonToggle euiButtonGroup__button"
-                        color="text"
-                        disabled={false}
-                        element="button"
-                        fill={false}
-                        id="throughput"
-                        isDisabled={false}
-                        size="s"
-                        tabIndex={-1}
-                        type="button"
-                      >
-                        <button
-                          className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
-                          disabled={false}
-                          id="throughput"
-                          tabIndex={-1}
-                          type="button"
-                        >
-                          <EuiButtonContent
-                            className="euiButton__content"
-                            iconSide="left"
-                            textProps={
-                              Object {
-                                "className": "euiButton__text",
-                              }
-                            }
-                          >
-                            <span
-                              className="euiButtonContent euiButton__content"
-                            >
-                              <span
-                                className="euiButton__text"
-                              >
-                                Throughput
-                              </span>
-                            </span>
-                          </EuiButtonContent>
-                        </button>
-                      </EuiButtonDisplay>
-                    </EuiButton>
-                  </div>
-                </EuiToggle>
-              </EuiButtonToggle>
-            </div>
-          </fieldset>
-        </EuiButtonGroup>
-        <EuiHorizontalRule
-          margin="m"
-        >
-          <hr
-            className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginMedium"
-          />
-        </EuiHorizontalRule>
-        <EuiFlexGroup
-          alignItems="center"
-          gutterSize="s"
-        >
-          <div
-            className="euiFlexGroup euiFlexGroup--gutterSmall euiFlexGroup--alignItemsCenter euiFlexGroup--directionRow euiFlexGroup--responsive"
-          >
-            <EuiFlexItem
-              grow={false}
-            >
-              <div
-                className="euiFlexItem euiFlexItem--flexGrowZero"
-              >
-                <EuiText>
-                  <div
-                    className="euiText euiText--medium"
-                  >
-                    Focus on
-                  </div>
-                </EuiText>
-              </div>
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <div
-                className="euiFlexItem"
-              >
-                <EuiFieldSearch
-                  compressed={false}
-                  fullWidth={false}
-                  incremental={false}
-                  isClearable={true}
-                  isInvalid={false}
-                  isLoading={false}
-                  onChange={[Function]}
-                  onSearch={[Function]}
-                  placeholder="Service name"
-                  value=""
-                >
-                  <EuiFormControlLayout
-                    compressed={false}
-                    fullWidth={false}
-                    icon="search"
-                    isLoading={false}
-                  >
-                    <div
-                      className="euiFormControlLayout"
-                    >
-                      <div
-                        className="euiFormControlLayout__childrenWrapper"
-                      >
-                        <EuiValidatableControl
-                          isInvalid={false}
-                        >
-                          <input
-                            className="euiFieldSearch euiFieldSearch-isClearable"
-                            onChange={[Function]}
-                            onKeyUp={[Function]}
-                            placeholder="Service name"
-                            type="search"
-                            value=""
-                          />
-                        </EuiValidatableControl>
-                        <EuiFormControlLayoutIcons
-                          icon="search"
-                          isLoading={false}
-                        >
-                          <div
-                            className="euiFormControlLayoutIcons"
-                          >
-                            <EuiFormControlLayoutCustomIcon
-                              type="search"
-                            >
-                              <span
-                                className="euiFormControlLayoutCustomIcon"
-                              >
-                                <EuiIcon
-                                  aria-hidden="true"
-                                  className="euiFormControlLayoutCustomIcon__icon"
-                                  type="search"
-                                >
-                                  <EuiIconEmpty
-                                    aria-hidden={true}
-                                    className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                    focusable="false"
-                                    role="img"
-                                    style={null}
-                                  >
-                                    <svg
-                                      aria-hidden={true}
-                                      className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                                      focusable="false"
-                                      height={16}
-                                      role="img"
-                                      style={null}
-                                      viewBox="0 0 16 16"
-                                      width={16}
-                                      xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
-                                </EuiIcon>
-                              </span>
-                            </EuiFormControlLayoutCustomIcon>
-                          </div>
-                        </EuiFormControlLayoutIcons>
-                      </div>
-                    </div>
-                  </EuiFormControlLayout>
-                </EuiFieldSearch>
-              </div>
-            </EuiFlexItem>
-          </div>
-        </EuiFlexGroup>
-        <EuiSpacer>
-          <div
-            className="euiSpacer euiSpacer--l"
-          />
-        </EuiSpacer>
-        <div
-          style={
-            Object {
-              "minHeight": 434,
-            }
-          }
-        >
-          <NoMatchMessage
-            size="s"
-          >
-            <EuiSpacer
-              size="s"
-            >
-              <div
-                className="euiSpacer euiSpacer--s"
-              />
-            </EuiSpacer>
-            <EuiEmptyPrompt
-              body={
-                <EuiText>
-                  No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                </EuiText>
-              }
-              title={
-                <h2>
-                  No matches
-                </h2>
-              }
-            >
-              <div
-                className="euiEmptyPrompt"
-              >
-                <EuiTextColor
-                  color="subdued"
-                >
-                  <span
-                    className="euiTextColor euiTextColor--subdued"
-                  >
-                    <EuiTitle
-                      size="m"
-                    >
-                      <h2
-                        className="euiTitle euiTitle--medium"
-                      >
-                        No matches
-                      </h2>
-                    </EuiTitle>
-                    <EuiSpacer
-                      size="m"
-                    >
-                      <div
-                        className="euiSpacer euiSpacer--m"
-                      />
-                    </EuiSpacer>
-                    <EuiText>
-                      <div
-                        className="euiText euiText--medium"
-                      >
-                        <EuiText>
-                          <div
-                            className="euiText euiText--medium"
-                          >
-                            No data matches the selected filter. Clear the filter and/or increase the time range to see more results.
-                          </div>
-                        </EuiText>
-                      </div>
-                    </EuiText>
-                  </span>
-                </EuiTextColor>
-              </div>
-            </EuiEmptyPrompt>
-            <EuiSpacer
-              size="s"
-            >
-              <div
-                className="euiSpacer euiSpacer--s"
-              />
-            </EuiSpacer>
-          </NoMatchMessage>
-        </div>
-      </div>
-    </EuiPanel>
-  </ServiceMap>
 </Services>
 `;

--- a/public/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
+++ b/public/components/services/__tests__/__snapshots__/services_table.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Services table component renders empty services table message 1`] = `
 <ServicesTable
   addFilter={[MockFunction]}
+  indicesExist={true}
   items={Array []}
   refresh={[MockFunction]}
   serviceQuery="test"
@@ -53,171 +54,18 @@ exports[`Services table component renders empty services table message 1`] = `
           </EuiFlexItem>
         </div>
       </EuiFlexGroup>
-      <EuiHorizontalRule
-        margin="s"
-        style={
-          Object {
-            "marginTop": 10,
-          }
-        }
+      <EuiSpacer
+        size="m"
       >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-          style={
-            Object {
-              "marginTop": 10,
-            }
-          }
+        <div
+          className="euiSpacer euiSpacer--m"
         />
-      </EuiHorizontalRule>
-      <EuiFieldSearch
-        compressed={false}
-        fullWidth={true}
-        incremental={false}
-        isClearable={true}
-        isLoading={false}
-        onChange={[Function]}
-        onSearch={[Function]}
-        placeholder="Service name"
-        value="test"
-      >
-        <EuiFormControlLayout
-          clear={
-            Object {
-              "onClick": [Function],
-            }
-          }
-          compressed={false}
-          fullWidth={true}
-          icon="search"
-          isLoading={false}
-        >
-          <div
-            className="euiFormControlLayout euiFormControlLayout--fullWidth"
-          >
-            <div
-              className="euiFormControlLayout__childrenWrapper"
-            >
-              <EuiValidatableControl>
-                <input
-                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
-                  onChange={[Function]}
-                  onKeyUp={[Function]}
-                  placeholder="Service name"
-                  type="search"
-                  value="test"
-                />
-              </EuiValidatableControl>
-              <EuiFormControlLayoutIcons
-                clear={
-                  Object {
-                    "onClick": [Function],
-                  }
-                }
-                icon="search"
-                isLoading={false}
-              >
-                <div
-                  className="euiFormControlLayoutIcons"
-                >
-                  <EuiFormControlLayoutCustomIcon
-                    type="search"
-                  >
-                    <span
-                      className="euiFormControlLayoutCustomIcon"
-                    >
-                      <EuiIcon
-                        aria-hidden="true"
-                        className="euiFormControlLayoutCustomIcon__icon"
-                        type="search"
-                      >
-                        <EuiIconEmpty
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          />
-                        </EuiIconEmpty>
-                      </EuiIcon>
-                    </span>
-                  </EuiFormControlLayoutCustomIcon>
-                </div>
-                <div
-                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                >
-                  <EuiFormControlLayoutClearButton
-                    onClick={[Function]}
-                  >
-                    <EuiI18n
-                      default="Clear input"
-                      token="euiFormControlLayoutClearButton.label"
-                    >
-                      <button
-                        aria-label="Clear input"
-                        className="euiFormControlLayoutClearButton"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <EuiIcon
-                          className="euiFormControlLayoutClearButton__icon"
-                          type="cross"
-                        >
-                          <EuiIconEmpty
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutClearButton__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutClearButton__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            />
-                          </EuiIconEmpty>
-                        </EuiIcon>
-                      </button>
-                    </EuiI18n>
-                  </EuiFormControlLayoutClearButton>
-                </div>
-              </EuiFormControlLayoutIcons>
-            </div>
-          </div>
-        </EuiFormControlLayout>
-      </EuiFieldSearch>
+      </EuiSpacer>
       <EuiHorizontalRule
-        margin="s"
-        style={
-          Object {
-            "marginBottom": 0,
-          }
-        }
+        margin="none"
       >
         <hr
-          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-          style={
-            Object {
-              "marginBottom": 0,
-            }
-          }
+          className="euiHorizontalRule euiHorizontalRule--full"
         />
       </EuiHorizontalRule>
       <NoMatchMessage
@@ -300,6 +148,7 @@ exports[`Services table component renders empty services table message 1`] = `
 exports[`Services table component renders services table 1`] = `
 <ServicesTable
   addFilter={[MockFunction]}
+  indicesExist={true}
   items={
     Array [
       Object {
@@ -362,179 +211,18 @@ exports[`Services table component renders services table 1`] = `
           </EuiFlexItem>
         </div>
       </EuiFlexGroup>
-      <EuiHorizontalRule
-        margin="s"
-        style={
-          Object {
-            "marginTop": 10,
-          }
-        }
+      <EuiSpacer
+        size="m"
       >
-        <hr
-          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-          style={
-            Object {
-              "marginTop": 10,
-            }
-          }
+        <div
+          className="euiSpacer euiSpacer--m"
         />
-      </EuiHorizontalRule>
-      <EuiFieldSearch
-        compressed={false}
-        fullWidth={true}
-        incremental={false}
-        isClearable={true}
-        isLoading={false}
-        onChange={[Function]}
-        onSearch={[Function]}
-        placeholder="Service name"
-        value="test"
-      >
-        <EuiFormControlLayout
-          clear={
-            Object {
-              "onClick": [Function],
-            }
-          }
-          compressed={false}
-          fullWidth={true}
-          icon="search"
-          isLoading={false}
-        >
-          <div
-            className="euiFormControlLayout euiFormControlLayout--fullWidth"
-          >
-            <div
-              className="euiFormControlLayout__childrenWrapper"
-            >
-              <EuiValidatableControl>
-                <input
-                  className="euiFieldSearch euiFieldSearch--fullWidth euiFieldSearch-isClearable"
-                  onChange={[Function]}
-                  onKeyUp={[Function]}
-                  placeholder="Service name"
-                  type="search"
-                  value="test"
-                />
-              </EuiValidatableControl>
-              <EuiFormControlLayoutIcons
-                clear={
-                  Object {
-                    "onClick": [Function],
-                  }
-                }
-                icon="search"
-                isLoading={false}
-              >
-                <div
-                  className="euiFormControlLayoutIcons"
-                >
-                  <EuiFormControlLayoutCustomIcon
-                    type="search"
-                  >
-                    <span
-                      className="euiFormControlLayoutCustomIcon"
-                    >
-                      <EuiIcon
-                        aria-hidden="true"
-                        className="euiFormControlLayoutCustomIcon__icon"
-                        type="search"
-                      >
-                        <EuiIconSearch
-                          aria-hidden={true}
-                          className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                          focusable="false"
-                          role="img"
-                          style={null}
-                        >
-                          <svg
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiFormControlLayoutCustomIcon__icon"
-                            focusable="false"
-                            height={16}
-                            role="img"
-                            style={null}
-                            viewBox="0 0 16 16"
-                            width={16}
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M11.271 11.978l3.872 3.873a.502.502 0 00.708 0 .502.502 0 000-.708l-3.565-3.564c2.38-2.747 2.267-6.923-.342-9.532-2.73-2.73-7.17-2.73-9.898 0-2.728 2.729-2.728 7.17 0 9.9a6.955 6.955 0 004.949 2.05.5.5 0 000-1 5.96 5.96 0 01-4.242-1.757 6.01 6.01 0 010-8.486c2.337-2.34 6.143-2.34 8.484 0a6.01 6.01 0 010 8.486.5.5 0 00.034.738z"
-                            />
-                          </svg>
-                        </EuiIconSearch>
-                      </EuiIcon>
-                    </span>
-                  </EuiFormControlLayoutCustomIcon>
-                </div>
-                <div
-                  className="euiFormControlLayoutIcons euiFormControlLayoutIcons--right"
-                >
-                  <EuiFormControlLayoutClearButton
-                    onClick={[Function]}
-                  >
-                    <EuiI18n
-                      default="Clear input"
-                      token="euiFormControlLayoutClearButton.label"
-                    >
-                      <button
-                        aria-label="Clear input"
-                        className="euiFormControlLayoutClearButton"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <EuiIcon
-                          className="euiFormControlLayoutClearButton__icon"
-                          type="cross"
-                        >
-                          <EuiIconCross
-                            aria-hidden={true}
-                            className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
-                            focusable="false"
-                            role="img"
-                            style={null}
-                          >
-                            <svg
-                              aria-hidden={true}
-                              className="euiIcon euiIcon--medium euiFormControlLayoutClearButton__icon"
-                              focusable="false"
-                              height={16}
-                              role="img"
-                              style={null}
-                              viewBox="0 0 16 16"
-                              width={16}
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M7.293 8L3.146 3.854a.5.5 0 11.708-.708L8 7.293l4.146-4.147a.5.5 0 01.708.708L8.707 8l4.147 4.146a.5.5 0 01-.708.708L8 8.707l-4.146 4.147a.5.5 0 01-.708-.708L7.293 8z"
-                              />
-                            </svg>
-                          </EuiIconCross>
-                        </EuiIcon>
-                      </button>
-                    </EuiI18n>
-                  </EuiFormControlLayoutClearButton>
-                </div>
-              </EuiFormControlLayoutIcons>
-            </div>
-          </div>
-        </EuiFormControlLayout>
-      </EuiFieldSearch>
+      </EuiSpacer>
       <EuiHorizontalRule
-        margin="s"
-        style={
-          Object {
-            "marginBottom": 0,
-          }
-        }
+        margin="none"
       >
         <hr
-          className="euiHorizontalRule euiHorizontalRule--full euiHorizontalRule--marginSmall"
-          style={
-            Object {
-              "marginBottom": 0,
-            }
-          }
+          className="euiHorizontalRule euiHorizontalRule--full"
         />
       </EuiHorizontalRule>
       <EuiInMemoryTable
@@ -1724,13 +1412,22 @@ exports[`Services table component renders services table 1`] = `
                               <div
                                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--truncateText euiTableCellContent--overflowingContent"
                               >
-                                <EuiI18nNumber
-                                  className=""
-                                  key=".0"
-                                  value={31}
+                                <EuiLink
+                                  onClick={[Function]}
                                 >
-                                  31
-                                </EuiI18nNumber>
+                                  <button
+                                    className="euiLink euiLink--primary"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="button"
+                                  >
+                                    <EuiI18nNumber
+                                      value={31}
+                                    >
+                                      31
+                                    </EuiI18nNumber>
+                                  </button>
+                                </EuiLink>
                               </div>
                             </td>
                           </EuiTableRowCell>

--- a/public/components/services/__tests__/services_table.test.tsx
+++ b/public/components/services/__tests__/services_table.test.tsx
@@ -35,6 +35,7 @@ describe('Services table component', () => {
         serviceQuery="test"
         setServiceQuery={setServiceQuery}
         refresh={refresh}
+        indicesExist={true}
       />
     );
 
@@ -65,14 +66,10 @@ describe('Services table component', () => {
         serviceQuery="test"
         setServiceQuery={setServiceQuery}
         refresh={refresh}
+        indicesExist={true}
       />
     );
 
     expect(wrapper).toMatchSnapshot();
-
-    wrapper
-      .find('input[placeholder="Service name"]')
-      .simulate('change', { target: { value: 'test' } });
-    expect(setServiceQuery).toBeCalledWith('test');
   });
 });

--- a/public/components/services/service_view.tsx
+++ b/public/components/services/service_view.tsx
@@ -14,12 +14,10 @@
  */
 
 import {
-  EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
   EuiI18nNumber,
-  EuiLink,
   EuiPage,
   EuiPageBody,
   EuiPanel,
@@ -71,7 +69,6 @@ export function ServiceView(props: ServiceViewProps) {
   }, [props.startTime, props.endTime]);
 
   const refresh = () => {
-    // const DSL = filtersToDsl([], '', props.startTime, props.endTime);
     const DSL = filtersToDsl(props.filters, props.query, props.startTime, props.endTime);
     handleServiceViewRequest(props.serviceName, props.http, DSL, fields, setFields);
     handleServiceMapRequest(props.http, DSL, serviceMap, setServiceMap, props.serviceName);
@@ -185,6 +182,11 @@ export function ServiceView(props: ServiceViewProps) {
     [props.serviceName, props.startTime, props.endTime]
   );
 
+  const activeFilters = useMemo(
+    () => props.filters.filter((filter) => !filter.locked && !filter.disabled),
+    [props.filters]
+  );
+
   return (
     <>
       <EuiPage>
@@ -192,6 +194,11 @@ export function ServiceView(props: ServiceViewProps) {
           <EuiFlexGroup alignItems="center" gutterSize="s">
             {title}
           </EuiFlexGroup>
+          {activeFilters.length > 0 && (
+            <EuiText textAlign="right" style={{ marginRight: 20 }} color="subdued">
+              results are filtered by {activeFilters.map((filter) => filter.field).join(', ')}
+            </EuiText>
+          )}
           <EuiSpacer size="xl" />
           {overview}
           <EuiSpacer />

--- a/public/components/services/service_view.tsx
+++ b/public/components/services/service_view.tsx
@@ -71,7 +71,8 @@ export function ServiceView(props: ServiceViewProps) {
   }, [props.startTime, props.endTime]);
 
   const refresh = () => {
-    const DSL = filtersToDsl([], '', props.startTime, props.endTime);
+    // const DSL = filtersToDsl([], '', props.startTime, props.endTime);
+    const DSL = filtersToDsl(props.filters, props.query, props.startTime, props.endTime);
     handleServiceViewRequest(props.serviceName, props.http, DSL, fields, setFields);
     handleServiceMapRequest(props.http, DSL, serviceMap, setServiceMap, props.serviceName);
   };

--- a/public/components/services/services.tsx
+++ b/public/components/services/services.tsx
@@ -17,10 +17,10 @@ import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { handleServicesRequest } from '../../requests/services_request_handler';
 import { CoreDeps } from '../app';
-import { filtersToDsl, MissingConfigurationMessage, SearchBar, SearchBarProps } from '../common';
+import { filtersToDsl, SearchBar, SearchBarProps } from '../common';
 import { FilterType } from '../common/filters/filters';
 import { getValidFilterFields } from '../common/filters/filter_helpers';
-import { ServiceMap, ServiceObject } from '../common/plots/service_map';
+import { ServiceObject } from '../common/plots/service_map';
 import { ServicesTable } from './services_table';
 
 interface ServicesProps extends SearchBarProps, CoreDeps {}
@@ -82,7 +82,6 @@ export function Services(props: ServicesProps) {
         <h2 style={{ fontWeight: 430 }}>Services</h2>
       </EuiTitle>
       <SearchBar
-        datepickerOnly={true}
         query={props.query}
         filters={props.filters}
         setFilters={props.setFilters}
@@ -95,26 +94,15 @@ export function Services(props: ServicesProps) {
         page="services"
       />
       <EuiSpacer />
-      {props.indicesExist ? (
-        <>
-          <ServicesTable
-            items={tableItems}
-            addFilter={addFilter}
-            setRedirect={setRedirect}
-            serviceQuery={serviceQuery}
-            setServiceQuery={setServiceQuery}
-            refresh={refresh}
-          />
-          <EuiSpacer />
-          <ServiceMap
-            serviceMap={serviceMap}
-            idSelected={serviceMapIdSelected}
-            setIdSelected={setServiceMapIdSelected}
-          />
-        </>
-      ) : (
-        <MissingConfigurationMessage />
-      )}
+      <ServicesTable
+        items={tableItems}
+        addFilter={addFilter}
+        setRedirect={setRedirect}
+        serviceQuery={serviceQuery}
+        setServiceQuery={setServiceQuery}
+        refresh={refresh}
+        indicesExist={props.indicesExist}
+      />
     </>
   );
 }

--- a/public/components/services/services_table.tsx
+++ b/public/components/services/services_table.tsx
@@ -14,7 +14,6 @@
  */
 
 import {
-  EuiFieldSearch,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -22,6 +21,7 @@ import {
   EuiInMemoryTable,
   EuiLink,
   EuiPanel,
+  EuiSpacer,
   EuiTableFieldDataColumnType,
   EuiText,
 } from '@elastic/eui';
@@ -144,16 +144,8 @@ export function ServicesTable(props: {
     <>
       <EuiPanel>
         {titleBar}
-        <EuiHorizontalRule margin="s" style={{ marginTop: 10 }} />
-        <EuiFieldSearch
-          fullWidth
-          placeholder="Service name"
-          value={props.serviceQuery}
-          onChange={(e) => props.setServiceQuery(e.target.value)}
-          onSearch={() => props.refresh()}
-        />
-        <EuiHorizontalRule margin="s" style={{ marginBottom: 0 }} />
-
+        <EuiSpacer size="m" />
+        <EuiHorizontalRule margin="none" />
         {props.items?.length > 0 ? (
           <EuiInMemoryTable
             tableLayout="auto"

--- a/public/components/services/services_table.tsx
+++ b/public/components/services/services_table.tsx
@@ -22,12 +22,11 @@ import {
   EuiInMemoryTable,
   EuiLink,
   EuiPanel,
-  EuiSpacer,
   EuiTableFieldDataColumnType,
   EuiText,
 } from '@elastic/eui';
 import _ from 'lodash';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { MissingConfigurationMessage, NoMatchMessage, PanelTitle } from '../common';
 import { FilterType } from '../common/filters/filters';
 
@@ -111,7 +110,29 @@ export function ServicesTable(props: {
           align: 'right',
           sortable: true,
           truncateText: true,
-          render: (item) => (item === 0 || item ? <EuiI18nNumber value={item} /> : '-'),
+          render: (item, row) => (
+            <>
+              {item === 0 || item ? (
+                <EuiLink
+                  onClick={() => {
+                    props.setRedirect(true);
+                    props.addFilter({
+                      field: 'serviceName',
+                      operator: 'is',
+                      value: row.name,
+                      inverted: false,
+                      disabled: false,
+                    });
+                    location.assign('#/traces');
+                  }}
+                >
+                  <EuiI18nNumber value={item} />
+                </EuiLink>
+              ) : (
+                '-'
+              )}
+            </>
+          ),
         },
       ] as Array<EuiTableFieldDataColumnType<any>>,
     [props.items]

--- a/public/components/services/services_table.tsx
+++ b/public/components/services/services_table.tsx
@@ -28,7 +28,7 @@ import {
 } from '@elastic/eui';
 import _ from 'lodash';
 import React, { useMemo, useState } from 'react';
-import { NoMatchMessage, PanelTitle } from '../common';
+import { MissingConfigurationMessage, NoMatchMessage, PanelTitle } from '../common';
 import { FilterType } from '../common/filters/filters';
 
 export function ServicesTable(props: {
@@ -38,6 +38,7 @@ export function ServicesTable(props: {
   serviceQuery: string;
   setServiceQuery: (query: string) => void;
   refresh: () => void;
+  indicesExist: boolean;
 }) {
   const renderTitleBar = (totalItems?: number) => {
     return (
@@ -148,8 +149,10 @@ export function ServicesTable(props: {
               },
             }}
           />
-        ) : (
+        ) : props.indicesExist ? (
           <NoMatchMessage size="xl" />
+        ) : (
+          <MissingConfigurationMessage />
         )}
       </EuiPanel>
     </>

--- a/public/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/traces.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`Traces component renders empty traces page 1`] = `
               isLoading={false}
               onChange={[Function]}
               onSearch={[Function]}
-              placeholder="Trace ID, trace group name"
+              placeholder="Trace ID, trace group name, service name"
               value=""
             >
               <EuiFormControlLayout
@@ -132,7 +132,7 @@ exports[`Traces component renders empty traces page 1`] = `
                         data-test-subj="search-bar-input-box"
                         onChange={[Function]}
                         onKeyUp={[Function]}
-                        placeholder="Trace ID, trace group name"
+                        placeholder="Trace ID, trace group name, service name"
                         type="search"
                         value=""
                       />
@@ -1203,7 +1203,7 @@ exports[`Traces component renders traces page 1`] = `
               isLoading={false}
               onChange={[Function]}
               onSearch={[Function]}
-              placeholder="Trace ID, trace group name"
+              placeholder="Trace ID, trace group name, service name"
               value=""
             >
               <EuiFormControlLayout
@@ -1224,7 +1224,7 @@ exports[`Traces component renders traces page 1`] = `
                         data-test-subj="search-bar-input-box"
                         onChange={[Function]}
                         onKeyUp={[Function]}
-                        placeholder="Trace ID, trace group name"
+                        placeholder="Trace ID, trace group name, service name"
                         type="search"
                         value=""
                       />

--- a/public/components/traces/traces_table.tsx
+++ b/public/components/traces/traces_table.tsx
@@ -138,6 +138,7 @@ export function TracesTable(props: {
   const onTableChange = async ({ page, sort }) => {
     if (typeof sort?.field !== 'string') return;
 
+    // maps table column key to DSL aggregation name
     const field = {
       trace_id: '_key',
       trace_group: null,

--- a/public/requests/dashboard_request_handler.ts
+++ b/public/requests/dashboard_request_handler.ts
@@ -105,7 +105,7 @@ export const handleDashboardRequest = async (
           return {
             dashboard_trace_group_name: bucket.key,
             dashboard_average_latency: bucket.average_latency.value,
-            dashboard_traces: bucket.doc_count,
+            dashboard_traces: bucket.trace_count.value,
             dashboard_latency_variance: latencyVariances[bucket.key],
             dashboard_error_rate: bucket.error_rate.value,
             ...latencyTrendData,

--- a/public/requests/dashboard_request_handler.ts
+++ b/public/requests/dashboard_request_handler.ts
@@ -134,7 +134,7 @@ export const handleDashboardThroughputPltRequest = (http, DSL, fixedInterval, it
           ? [
               {
                 x: buckets.map((bucket) => bucket.key),
-                y: buckets.map((bucket) => bucket.doc_count),
+                y: buckets.map((bucket) => bucket.trace_count.value),
                 marker: {
                   color: 'rgb(171, 211, 240)',
                 },

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -18,7 +18,15 @@ export const getDashboardQuery = () => {
     size: 0,
     query: {
       bool: {
-        must: [],
+        must: [
+          {
+            term: {
+              parentSpanId: {
+                value: '',
+              },
+            },
+          },
+        ],
         filter: [],
         should: [],
         must_not: [],

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -190,6 +190,13 @@ export const getDashboardThroughputPltQuery = (fixedInterval) => {
           field: 'startTime',
           fixed_interval: fixedInterval,
         },
+        aggs: {
+          trace_count: {
+            cardinality: {
+              field: 'traceId',
+            },
+          },
+        },
       },
     },
   };

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -100,7 +100,15 @@ export const getDashboardTraceGroupPercentiles = () => {
     size: 0,
     query: {
       bool: {
-        must: [],
+        must: [
+          {
+            term: {
+              parentSpanId: {
+                value: '',
+              },
+            },
+          },
+        ],
         filter: [],
         should: [],
         must_not: [],
@@ -131,8 +139,10 @@ export const getErrorRatePltQuery = (fixedInterval) => {
       bool: {
         must: [
           {
-            exists: {
-              field: 'traceGroup',
+            term: {
+              parentSpanId: {
+                value: '',
+              },
             },
           },
         ],
@@ -178,8 +188,10 @@ export const getDashboardThroughputPltQuery = (fixedInterval) => {
       bool: {
         must: [
           {
-            exists: {
-              field: 'traceGroup',
+            term: {
+              parentSpanId: {
+                value: '',
+              },
             },
           },
         ],

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -18,15 +18,7 @@ export const getDashboardQuery = () => {
     size: 0,
     query: {
       bool: {
-        must: [
-          {
-            term: {
-              parentSpanId: {
-                value: '',
-              },
-            },
-          },
-        ],
+        must: [],
         filter: [],
         should: [],
         must_not: [],
@@ -73,6 +65,11 @@ export const getDashboardQuery = () => {
                 latency: 'average_latency_nanos.value',
               },
               script: 'Math.round(params.latency / 10000) / 100.0',
+            },
+          },
+          trace_count: {
+            cardinality: {
+              field: 'traceId',
             },
           },
           error_count: {

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -137,15 +137,7 @@ export const getErrorRatePltQuery = (fixedInterval) => {
     size: 0,
     query: {
       bool: {
-        must: [
-          {
-            term: {
-              parentSpanId: {
-                value: '',
-              },
-            },
-          },
-        ],
+        must: [],
         filter: [],
         should: [],
         must_not: [],
@@ -186,15 +178,7 @@ export const getDashboardThroughputPltQuery = (fixedInterval) => {
     size: 0,
     query: {
       bool: {
-        must: [
-          {
-            term: {
-              parentSpanId: {
-                value: '',
-              },
-            },
-          },
-        ],
+        must: [],
         filter: [],
         should: [],
         must_not: [],

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -165,10 +165,15 @@ export const getErrorRatePltQuery = (fixedInterval) => {
               },
             },
           },
+          trace_count: {
+            cardinality: {
+              field: 'traceId',
+            },
+          },
           error_rate: {
             bucket_script: {
               buckets_path: {
-                total: '_count',
+                total: 'trace_count.value',
                 errors: 'error_count>trace_count.value',
               },
               script: 'params.errors / params.total * 100',

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -27,7 +27,7 @@ export const getDashboardQuery = () => {
     aggs: {
       trace_group_name: {
         terms: {
-          field: 'traceGroup',
+          field: 'traceGroup.name',
           size: 10000,
         },
         aggs: {
@@ -75,6 +75,7 @@ export const getDashboardQuery = () => {
           error_count: {
             filter: {
               term: {
+                // TODO change to traceGroup statuscode, and add another aggs like throughput plot
                 'status.code': '2',
               },
             },
@@ -117,7 +118,7 @@ export const getDashboardTraceGroupPercentiles = () => {
     aggs: {
       trace_group: {
         terms: {
-          field: 'traceGroup',
+          field: 'traceGroup.name',
         },
         aggs: {
           latency_variance_nanos: {

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -153,7 +153,15 @@ export const getErrorRatePltQuery = (fixedInterval) => {
           error_count: {
             filter: {
               term: {
+                // TODO: change to traceGroup.statuscode
                 'status.code': '2',
+              },
+            },
+            aggs: {
+              trace_count: {
+                cardinality: {
+                  field: 'traceId',
+                },
               },
             },
           },
@@ -161,7 +169,7 @@ export const getErrorRatePltQuery = (fixedInterval) => {
             bucket_script: {
               buckets_path: {
                 total: '_count',
-                errors: 'error_count._count',
+                errors: 'error_count>trace_count.value',
               },
               script: 'params.errors / params.total * 100',
             },

--- a/public/requests/queries/services_queries.ts
+++ b/public/requests/queries/services_queries.ts
@@ -197,8 +197,8 @@ export const getServiceEdgesQuery = (source: 'destination' | 'target') => {
 export const getServiceMetricsQuery = (DSL, serviceNames: string[], map: ServiceObject) => {
   const traceGroupFilter = new Set(
     DSL?.query?.bool.must
-      .filter((must) => must.term?.traceGroup)
-      .map((must) => must.term.traceGroup) || []
+      .filter((must) => must.term?.['traceGroup.name'])
+      .map((must) => must.term['traceGroup.name']) || []
   );
 
   const targetResource =

--- a/public/requests/queries/services_queries.ts
+++ b/public/requests/queries/services_queries.ts
@@ -195,7 +195,12 @@ export const getServiceEdgesQuery = (source: 'destination' | 'target') => {
 };
 
 export const getServiceMetricsQuery = (DSL, serviceNames: string[], map: ServiceObject) => {
-  const traceGroupFilter = new Set(DSL.custom?.traceGroup);
+  const traceGroupFilter = new Set(
+    DSL?.query?.bool.must
+      .filter((must) => must.term?.traceGroup)
+      .map((must) => must.term.traceGroup) || []
+  );
+
   const targetResource =
     traceGroupFilter.size > 0
       ? [].concat(

--- a/public/requests/queries/services_queries.ts
+++ b/public/requests/queries/services_queries.ts
@@ -230,9 +230,10 @@ export const getServiceMetricsQuery = (DSL, serviceNames: string[], map: Service
                       {
                         bool: {
                           must_not: {
-                            exists: {
-                              field: 'traceGroup',
-                              boost: 1,
+                            term: {
+                              parentSpanId: {
+                                value: '',
+                              },
                             },
                           },
                         },
@@ -248,9 +249,10 @@ export const getServiceMetricsQuery = (DSL, serviceNames: string[], map: Service
                 {
                   bool: {
                     must: {
-                      exists: {
-                        field: 'traceGroup',
-                        boost: 1,
+                      term: {
+                        parentSpanId: {
+                          value: '',
+                        },
                       },
                     },
                   },

--- a/public/requests/queries/traces_queries.ts
+++ b/public/requests/queries/traces_queries.ts
@@ -81,7 +81,7 @@ export const getTracesQuery = (traceId = null, sort?: PropertySort) => {
           latency: {
             max: {
               script: {
-                source: "Math.round(doc['durationInNanos'].value / 10000) / 100.0",
+                source: "Math.round(doc['traceGroup.durationInNanos'].value / 10000) / 100.0",
                 lang: 'painless',
               },
             },
@@ -95,13 +95,13 @@ export const getTracesQuery = (traceId = null, sort?: PropertySort) => {
           error_count: {
             filter: {
               term: {
-                'status.code': '2',
+                'traceGroup.statusCode': '2',
               },
             },
           },
           last_updated: {
             max: {
-              field: 'endTime',
+              field: 'traceGroup.endTime',
             },
           },
         },

--- a/public/requests/queries/traces_queries.ts
+++ b/public/requests/queries/traces_queries.ts
@@ -88,7 +88,7 @@ export const getTracesQuery = (traceId = null, sort?: PropertySort) => {
           },
           trace_group: {
             terms: {
-              field: 'traceGroup',
+              field: 'traceGroup.name',
               size: 1,
             },
           },

--- a/public/requests/queries/traces_queries.ts
+++ b/public/requests/queries/traces_queries.ts
@@ -23,8 +23,10 @@ export const getTraceGroupPercentilesQuery = () => {
       bool: {
         must: [
           {
-            exists: {
-              field: 'traceGroup',
+            term: {
+              parentSpanId: {
+                value: '',
+              },
             },
           },
         ],
@@ -60,13 +62,7 @@ export const getTracesQuery = (traceId = null, sort?: PropertySort) => {
     size: 0,
     query: {
       bool: {
-        must: [
-          {
-            exists: {
-              field: 'traceGroup',
-            },
-          },
-        ],
+        must: [],
         filter: [],
         should: [],
         must_not: [],
@@ -92,7 +88,7 @@ export const getTracesQuery = (traceId = null, sort?: PropertySort) => {
           },
           trace_group: {
             terms: {
-              field: 'name',
+              field: 'traceGroup',
               size: 1,
             },
           },

--- a/public/requests/services_request_handler.ts
+++ b/public/requests/services_request_handler.ts
@@ -114,7 +114,7 @@ export const handleServiceMapRequest = async (http, DSL, items?, setItems?, curr
   // service map handles DSL differently
   const latencies = await handleDslRequest(
     http,
-    {},
+    DSL,
     getServiceMetricsQuery(DSL, Object.keys(map), map)
   );
   latencies.aggregations.service_name.buckets.map((bucket) => {

--- a/public/requests/services_request_handler.ts
+++ b/public/requests/services_request_handler.ts
@@ -147,7 +147,7 @@ export const handleServiceViewRequest = (serviceName, http, DSL, fields, setFiel
     .then(async (response) => {
       const bucket = response.aggregations.service.buckets[0];
       if (!bucket) return {};
-      const serviceObject: ServiceObject = await handleServiceMapRequest(http, {});
+      const serviceObject: ServiceObject = await handleServiceMapRequest(http, DSL);
       const connectedServices = [
         ...serviceObject[bucket.key].targetServices,
         ...serviceObject[bucket.key].destServices,

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -45,7 +45,7 @@ export const handleTracesRequest = async (http, DSL, timeFilterDSL, items, setIt
       if (arr[mid] < target) low = mid + 1;
       else high = mid;
     }
-    return low;
+    return Math.max(0, Math.min(100, low));
   };
 
   // percentile should only be affected by timefilter


### PR DESCRIPTION
*Issue #, if available:*
#27 

*Description of changes:*
- Move service map back to dashboard
- Update queries to use these fields to allow filtering by `traceGroup.name` and `serviceName` on dashboard and services page
```
traceGroup.durationInNanos
traceGroup.endTime
traceGroup.status.code
traceGroup.name
```
- Bug fixes
- Update unit tests

 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 