### PR TITLE
Add null check for service map, fix percentile filter

### DIFF
--- a/public/components/dashboard/dashboard.tsx
+++ b/public/components/dashboard/dashboard.tsx
@@ -122,11 +122,17 @@ export function Dashboard(props: DashboardProps) {
     if (tableItems.length === 0 || Object.keys(percentileMap).length === 0) return;
     for (let i = 0; i < props.filters.length; i++) {
       if (props.filters[i].custom) {
-        const newFilter = JSON.parse(
-          JSON.stringify(props.filters[i]).replace(
-            /{"range":{"durationInNanos":{"[gl]te?"/g,
-            `{"range":{"durationInNanos":{"${condition}"`
-          )
+        const newFilter = JSON.parse(JSON.stringify(props.filters[i]));
+        newFilter.custom.query.bool.should.forEach((should) =>
+          should.bool.must.forEach((must) => {
+            const range = must?.range?.['traceGroupFields.durationInNanos'];
+            if (range) {
+              const duration = range.lt || range.lte || range.gt || range.gte;
+              must.range['traceGroupFields.durationInNanos'] = {
+                [condition]: duration,
+              };
+            }
+          })
         );
         newFilter.value = condition === 'gte' ? '>= 95th' : '< 95th';
         const newFilters = [...props.filters, ...additionalFilters];

--- a/public/components/dashboard/dashboard.tsx
+++ b/public/components/dashboard/dashboard.tsx
@@ -128,9 +128,11 @@ export function Dashboard(props: DashboardProps) {
             const range = must?.range?.['traceGroupFields.durationInNanos'];
             if (range) {
               const duration = range.lt || range.lte || range.gt || range.gte;
-              must.range['traceGroupFields.durationInNanos'] = {
-                [condition]: duration,
-              };
+              if (duration || duration === 0) {
+                must.range['traceGroupFields.durationInNanos'] = {
+                  [condition]: duration,
+                };
+              }
             }
           })
         );

--- a/public/requests/services_request_handler.ts
+++ b/public/requests/services_request_handler.ts
@@ -37,21 +37,23 @@ export const handleServicesRequest = async (
       const serviceObject: ServiceObject = await handleServiceMapRequest(http, DSL);
       if (setServiceMap) setServiceMap(serviceObject);
       return Promise.all(
-        response.aggregations.service.buckets.map((bucket) => {
-          const connectedServices = [
-            ...serviceObject[bucket.key].targetServices,
-            ...serviceObject[bucket.key].destServices,
-          ];
-          return {
-            name: bucket.key,
-            average_latency: serviceObject[bucket.key].latency,
-            error_rate: serviceObject[bucket.key].error_rate,
-            throughput: serviceObject[bucket.key].throughput,
-            traces: bucket.trace_count.value,
-            connected_services: connectedServices.join(', '),
-            number_of_connected_services: connectedServices.length,
-          };
-        })
+        response.aggregations.service.buckets
+          .filter((bucket) => serviceObject[bucket.key])
+          .map((bucket) => {
+            const connectedServices = [
+              ...serviceObject[bucket.key].targetServices,
+              ...serviceObject[bucket.key].destServices,
+            ];
+            return {
+              name: bucket.key,
+              average_latency: serviceObject[bucket.key].latency,
+              error_rate: serviceObject[bucket.key].error_rate,
+              throughput: serviceObject[bucket.key].throughput,
+              traces: bucket.trace_count.value,
+              connected_services: connectedServices.join(', '),
+              number_of_connected_services: connectedServices.length,
+            };
+          })
       );
     })
     .then((newItems) => {
@@ -100,10 +102,12 @@ export const handleServiceMapRequest = async (http, DSL, items?, setItems?, curr
           bucket.resource.buckets.map((resource) => {
             resource.domain.buckets.map((domain) => {
               const targetService = targets[resource.key + ':' + domain.key];
-              if (map[bucket.key].targetServices.indexOf(targetService) === -1)
-                map[bucket.key].targetServices.push(targetService);
-              if (map[targetService].destServices.indexOf(bucket.key) === -1)
-                map[targetService].destServices.push(bucket.key);
+              if (targetService) {
+                if (map[bucket.key].targetServices.indexOf(targetService) === -1)
+                  map[bucket.key].targetServices.push(targetService);
+                if (map[targetService].destServices.indexOf(bucket.key) === -1)
+                  map[targetService].destServices.push(bucket.key);
+              }
             });
           });
         })


### PR DESCRIPTION
*Issue #, if available:*
- #32 
- https://github.com/opendistro-for-elasticsearch/data-prepper/issues/479

*Description of changes:*
- Add null check when querying for service map to handle edge cases
- Fix percentile filter to use `traceGroupFields.durationInNanos` rather than `durationInNanos`

 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 