### PR TITLE
Use separate latency trend query

### DIFF
--- a/.cypress/integration/dashboard.spec.js
+++ b/.cypress/integration/dashboard.spec.js
@@ -62,7 +62,7 @@ describe('Testing dashboard table', () => {
     cy.contains('383.05').should('exist');
   });
 
-  it.only('Opens latency trend popover', () => {
+  it('Opens latency trend popover', () => {
     setTimeFilter(true);
     cy.get('.euiButtonIcon[aria-label="Open popover"]').first().click();
     cy.get('text.ytitle[data-unformatted="Hourly latency (ms)"]').should('exist');

--- a/.cypress/integration/dashboard.spec.js
+++ b/.cypress/integration/dashboard.spec.js
@@ -62,7 +62,8 @@ describe('Testing dashboard table', () => {
     cy.contains('383.05').should('exist');
   });
 
-  it('Opens latency trend popover', () => {
+  it.only('Opens latency trend popover', () => {
+    setTimeFilter(true);
     cy.get('.euiButtonIcon[aria-label="Open popover"]').first().click();
     cy.get('text.ytitle[data-unformatted="Hourly latency (ms)"]').should('exist');
   });

--- a/.cypress/integration/services.spec.js
+++ b/.cypress/integration/services.spec.js
@@ -67,7 +67,7 @@ describe('Testing service view empty state', () => {
 describe('Testing service view', () => {
   beforeEach(() => {
     cy.visit(`app/opendistro-trace-analytics#/services/${SERVICE_NAME}`);
-    setTimeFilter(undefined, undefined, false);
+    setTimeFilter(undefined, false);
   });
   
   it('Renders service view', () => {

--- a/.cypress/utils/constants.js
+++ b/.cypress/utils/constants.js
@@ -18,11 +18,9 @@ export const TRACE_ID = '8832ed6abbb2a83516461960c89af49d';
 export const SPAN_ID = 'a673bc074b438374';
 export const SERVICE_NAME = 'frontend-client';
 
-export const setTimeFilter = (
-  startTime = 'Mar 25, 2021 @ 10:00:00.000',
-  endTime = 'Mar 25, 2021 @ 11:00:00.000',
-  refresh = true
-) => {
+export const setTimeFilter = (setEndTime = false, refresh = true) => {
+  const startTime = 'Mar 25, 2021 @ 10:00:00.000';
+  const endTime = 'Mar 25, 2021 @ 11:00:00.000';
   cy.get('button.euiButtonEmpty[aria-label="Date quick select"]').click();
   cy.get('.euiQuickSelect__applyButton').click();
   cy.get('.euiSuperDatePicker__prettyFormatLink').click();
@@ -33,6 +31,17 @@ export const setTimeFilter = (
   cy.get('input[data-test-subj="superDatePickerAbsoluteDateInput"]')
     .focus()
     .type('{selectall}' + startTime);
+  if (setEndTime) {
+    cy.wait(delay);
+    cy.get(
+      'button.euiDatePopoverButton--end[data-test-subj="superDatePickerendDatePopoverButton"]'
+    ).click();
+    cy.wait(delay);
+    cy.get('.euiTab__content').contains('Absolute').click();
+    cy.get('input[data-test-subj="superDatePickerAbsoluteDateInput"]')
+      .focus()
+      .type('{selectall}' + endTime);
+  }
   if (refresh) cy.get('.euiButton__text').contains('Refresh').click();
   cy.wait(delay);
 };

--- a/public/components/dashboard/dashboard.tsx
+++ b/public/components/dashboard/dashboard.tsx
@@ -13,6 +13,7 @@
  *   permissions and limitations under the License.
  */
 
+import dateMath from '@elastic/datemath';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import {
@@ -77,12 +78,23 @@ export function Dashboard(props: DashboardProps) {
   const refresh = async () => {
     const DSL = filtersToDsl(props.filters, props.query, props.startTime, props.endTime);
     const timeFilterDSL = filtersToDsl([], '', props.startTime, props.endTime);
+    const latencyTrendStartTime = dateMath
+      .parse(props.endTime)
+      ?.subtract(24, 'hours')
+      .toISOString()!;
+    const latencyTrendDSL = filtersToDsl(
+      props.filters,
+      props.query,
+      latencyTrendStartTime,
+      props.endTime
+    );
     const fixedInterval = minFixedInterval(props.startTime, props.endTime);
 
     handleDashboardRequest(
       props.http,
       DSL,
       timeFilterDSL,
+      latencyTrendDSL,
       tableItems,
       setTableItems,
       setPercentileMap

--- a/public/requests/dashboard_request_handler.ts
+++ b/public/requests/dashboard_request_handler.ts
@@ -15,13 +15,14 @@
 
 import _ from 'lodash';
 import moment from 'moment';
-import { DATE_FORMAT, DATE_PICKER_FORMAT } from '../../common';
+import { DATE_PICKER_FORMAT } from '../../common';
 import { fixedIntervalToMilli, nanoToMilliSec } from '../components/common/helper_functions';
 import {
   getDashboardQuery,
   getDashboardThroughputPltQuery,
   getDashboardTraceGroupPercentiles,
   getErrorRatePltQuery,
+  getLatencyTrendQuery,
 } from './queries/dashboard_queries';
 import { handleDslRequest } from './request_handler';
 
@@ -29,6 +30,7 @@ export const handleDashboardRequest = async (
   http,
   DSL,
   timeFilterDSL,
+  latencyTrendDSL,
   items,
   setItems,
   setPercentileMap?
@@ -51,64 +53,73 @@ export const handleDashboardRequest = async (
     .catch((error) => console.error(error));
   if (setPercentileMap) setPercentileMap(latencyVariances);
 
+  const latencyTrends = await handleDslRequest(http, latencyTrendDSL, getLatencyTrendQuery())
+    .then((response) => {
+      const map: any = {};
+      response.aggregations.trace_group_name.buckets.map((bucket) => {
+        const latencyTrend = bucket.group_by_hour.buckets
+          .slice(-24)
+          .filter((bucket) => bucket.average_latency?.value || bucket.average_latency?.value === 0);
+        const values = {
+          x: latencyTrend.map((bucket) => bucket.key),
+          y: latencyTrend.map((bucket) => bucket.average_latency?.value || 0),
+        };
+        const latencyTrendData =
+          values.x?.length > 0
+            ? {
+                '24_hour_latency_trend': {
+                  trendData: [
+                    {
+                      ...values,
+                      type: 'scatter',
+                      mode: 'lines',
+                      hoverinfo: 'none',
+                      line: {
+                        color: '#000000',
+                        width: 1,
+                      },
+                    },
+                  ],
+                  popoverData: [
+                    {
+                      ...values,
+                      type: 'scatter',
+                      mode: 'lines+markers',
+                      hovertemplate: '%{x}<br>Average latency: %{y}<extra></extra>',
+                      hoverlabel: {
+                        bgcolor: '#d7c2ff',
+                      },
+                      marker: {
+                        color: '#987dcb',
+                        size: 8,
+                      },
+                      line: {
+                        color: '#987dcb',
+                        size: 2,
+                      },
+                    },
+                  ],
+                },
+              }
+            : {};
+        map[bucket.key] = latencyTrendData;
+      });
+      return map;
+    })
+    .catch((error) => console.error(error));
+
   handleDslRequest(http, DSL, getDashboardQuery())
     .then((response) => {
       return Promise.all(
         response.aggregations.trace_group_name.buckets.map((bucket) => {
-          const latencyTrend = bucket.group_by_hour.buckets
-            .slice(-24)
-            .filter(
-              (bucket) => bucket.average_latency?.value || bucket.average_latency?.value === 0
-            );
-          const values = {
-            x: latencyTrend.map((bucket) => bucket.key),
-            y: latencyTrend.map((bucket) => bucket.average_latency?.value || 0),
-          };
-          const latencyTrendData =
-            values.x?.length > 0
-              ? {
-                  '24_hour_latency_trend': {
-                    trendData: [
-                      {
-                        ...values,
-                        type: 'scatter',
-                        mode: 'lines',
-                        hoverinfo: 'none',
-                        line: {
-                          color: '#000000',
-                          width: 1,
-                        },
-                      },
-                    ],
-                    popoverData: [
-                      {
-                        ...values,
-                        type: 'scatter',
-                        mode: 'lines+markers',
-                        hovertemplate: '%{x}<br>Average latency: %{y}<extra></extra>',
-                        hoverlabel: {
-                          bgcolor: '#d7c2ff',
-                        },
-                        marker: {
-                          color: '#987dcb',
-                          size: 8,
-                        },
-                        line: {
-                          color: '#987dcb',
-                          size: 2,
-                        },
-                      },
-                    ],
-                  },
-                }
-              : {};
+          const latencyTrend = latencyTrends[bucket.key] || {};
           return {
             dashboard_trace_group_name: bucket.key,
             dashboard_average_latency: bucket.average_latency?.value,
             dashboard_traces: bucket.trace_count.value,
             dashboard_latency_variance: latencyVariances[bucket.key],
             dashboard_error_rate: bucket.error_rate.value,
-            ...latencyTrendData,
+            ...latencyTrend,
           };
         })
       );

--- a/public/requests/dashboard_request_handler.ts
+++ b/public/requests/dashboard_request_handler.ts
@@ -104,7 +104,7 @@ export const handleDashboardRequest = async (
               : {};
           return {
             dashboard_trace_group_name: bucket.key,
-            dashboard_average_latency: bucket.average_latency.value,
+            dashboard_average_latency: bucket.average_latency?.value,
             dashboard_traces: bucket.trace_count.value,
             dashboard_latency_variance: latencyVariances[bucket.key],
             dashboard_error_rate: bucket.error_rate.value,

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -31,49 +31,6 @@ export const getDashboardQuery = () => {
           size: 10000,
         },
         aggs: {
-          group_by_hour: {
-            date_histogram: {
-              field: 'endTime',
-              calendar_interval: 'hour',
-            },
-            aggs: {
-              traces: {
-                terms: {
-                  field: 'traceId',
-                  order: {
-                    last_updated: 'desc',
-                  },
-                  size: 10000,
-                },
-                aggs: {
-                  duration: {
-                    max: {
-                      field: 'traceGroupFields.durationInNanos',
-                    },
-                  },
-                  last_updated: {
-                    max: {
-                      field: 'traceGroupFields.endTime',
-                    },
-                  },
-                },
-              },
-              average_latency_nanos: {
-                avg_bucket: {
-                  buckets_path: 'traces>duration',
-                },
-              },
-              average_latency: {
-                bucket_script: {
-                  buckets_path: {
-                    count: '_count',
-                    latency: 'average_latency_nanos.value',
-                  },
-                  script: 'Math.round(params.latency / 10000) / 100.0',
-                },
-              },
-            },
-          },
           traces: {
             terms: {
               field: 'traceId',
@@ -143,6 +100,74 @@ export const getDashboardQuery = () => {
   };
   return query;
 };
+
+export const getLatencyTrendQuery = () => {
+  const query = {
+    size: 0,
+    query: {
+      bool: {
+        must: [],
+        filter: [],
+        should: [],
+        must_not: [],
+      },
+    },
+    aggs: {
+      trace_group_name: {
+        terms: {
+          field: 'traceGroup',
+          size: 10000,
+        },
+        aggs: {
+          group_by_hour: {
+            date_histogram: {
+              field: 'endTime',
+              calendar_interval: 'hour',
+            },
+            aggs: {
+              traces: {
+                terms: {
+                  field: 'traceId',
+                  order: {
+                    last_updated: 'desc',
+                  },
+                  size: 10000,
+                },
+                aggs: {
+                  duration: {
+                    max: {
+                      field: 'traceGroupFields.durationInNanos',
+                    },
+                  },
+                  last_updated: {
+                    max: {
+                      field: 'traceGroupFields.endTime',
+                    },
+                  },
+                },
+              },
+              average_latency_nanos: {
+                avg_bucket: {
+                  buckets_path: 'traces>duration',
+                },
+              },
+              average_latency: {
+                bucket_script: {
+                  buckets_path: {
+                    count: '_count',
+                    latency: 'average_latency_nanos.value',
+                  },
+                  script: 'Math.round(params.latency / 10000) / 100.0',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  return query;
+}
 
 export const getDashboardTraceGroupPercentiles = () => {
   return {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- use separate latency trend query to set time filter to be `endTime - 24 hours` to `endTime`
- fix a bug to prevent crash when latency is undefined
- update cypress setting time filter

 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 