### PR TITLE
Increase truncation point, add tooltip if text is truncated

### DIFF
--- a/public/components/dashboard/dashboard_table.tsx
+++ b/public/components/dashboard/dashboard_table.tsx
@@ -119,7 +119,7 @@ export function DashboardTable(props: {
                 })
               }
             >
-              {_.truncate(item, { length: 24 })}
+              {item.length < 48 ? item : <div title={item}>{_.truncate(item, { length: 48 })}</div>}
             </EuiLink>
           ) : (
             '-'

--- a/public/components/services/services_table.tsx
+++ b/public/components/services/services_table.tsx
@@ -59,7 +59,7 @@ export function ServicesTable(props: {
           sortable: true,
           render: (item) => (
             <EuiLink href={`#/services/${encodeURIComponent(item)}`}>
-              {_.truncate(item, { length: 24 })}
+              {item.length < 24 ? item : <div title={item}>{_.truncate(item, { length: 24 })}</div>}
             </EuiLink>
           ),
         },

--- a/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -1334,7 +1334,11 @@ exports[`Traces table component renders traces table 1`] = `
                                             href="#/traces/00079a615e31e61766fcb20b557051c1"
                                             rel="noreferrer"
                                           >
-                                            00079a615e31e61766fcb...
+                                            <div
+                                              title="00079a615e31e61766fcb20b557051c1"
+                                            >
+                                              00079a615e31e61766fcb...
+                                            </div>
                                           </a>
                                         </EuiLink>
                                       </div>

--- a/public/components/traces/traces_table.tsx
+++ b/public/components/traces/traces_table.tsx
@@ -60,7 +60,11 @@ export function TracesTable(props: {
             <EuiFlexGroup gutterSize="s" alignItems="center">
               <EuiFlexItem grow={10}>
                 <EuiLink href={`#/traces/${encodeURIComponent(item)}`}>
-                  {_.truncate(item, { length: 24 })}
+                  {item.length < 24 ? (
+                    item
+                  ) : (
+                    <div title={item}>{_.truncate(item, { length: 24 })}</div>
+                  )}
                 </EuiLink>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
@@ -86,7 +90,18 @@ export function TracesTable(props: {
           align: 'left',
           sortable: true,
           truncateText: true,
-          render: (item) => item ? <EuiText size="s">{_.truncate(item, { length: 24 })}</EuiText> : '-',
+          render: (item) =>
+            item ? (
+              <EuiText size="s">
+                {item.length < 36 ? (
+                  item
+                ) : (
+                  <div title={item}>{_.truncate(item, { length: 36 })}</div>
+                )}
+              </EuiText>
+            ) : (
+              '-'
+            ),
         },
         {
           field: 'latency',


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/opensearch-project/trace-analytics/issues/16
- #31 

*Description of changes:*
- Increase truncation point of some elements
- add hover tooltip to display complete text if text is truncated

 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 