### PR TITLE
Use scripted metrics instead of terms query to reduce number of buckets

### DIFF
--- a/public/requests/dashboard_request_handler.ts
+++ b/public/requests/dashboard_request_handler.ts
@@ -112,7 +112,7 @@ export const handleDashboardRequest = async (
     .then((response) => {
       return Promise.all(
         response.aggregations.trace_group_name.buckets.map((bucket) => {
-          const latencyTrend = latencyTrends[bucket.key] || {};
+          const latencyTrend = latencyTrends?.[bucket.key] || {};
           return {
             dashboard_trace_group_name: bucket.key,
             dashboard_average_latency: bucket.average_latency?.value,

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -48,10 +48,16 @@ export const getDashboardQuery = () => {
                 return state.total_latency / state.count;
               `,
               reduce_script: `
-                def total = 0.0;
-                for (latency_nanos in states)
-                  total += (latency_nanos instanceof Double ? latency_nanos : 0);
-                return Math.round(total / states.size() / 10000) / 100.0;
+                double total = 0.0;
+                int length = 0;
+                for (latency_nanos in states) {
+                  if (latency_nanos != null) {
+                    length++;
+                    total += latency_nanos;
+                  }
+                }
+                if (length == 0) return null;
+                return Math.round(total / length / 10000) / 100.0;
               `,
             },
           },
@@ -131,10 +137,16 @@ export const getLatencyTrendQuery = () => {
                     return state.total_latency / state.count;
                   `,
                   reduce_script: `
-                    def total = 0.0;
-                    for (latency_nanos in states)
-                      total += (latency_nanos instanceof Double ? latency_nanos : 0);
-                    return Math.round(total / states.size() / 10000) / 100.0;
+                    double total = 0.0;
+                    int length = 0;
+                    for (latency_nanos in states) {
+                      if (latency_nanos != null) {
+                        length++;
+                        total += latency_nanos;
+                      }
+                    }
+                    if (length == 0) return null;
+                    return Math.round(total / length / 10000) / 100.0;
                   `,
                 },
               },

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -45,10 +45,14 @@ export const getDashboardQuery = () => {
                 }
                 `,
               combine_script: `
-                def average_latency_nanos = state.total_latency / state.count;
-                return Math.round(average_latency_nanos / 10000) / 100.0;
-                `,
-              reduce_script: 'return states[0]',
+                return state.total_latency / state.count;
+              `,
+              reduce_script: `
+                def total = 0.0;
+                for (latency_nanos in states)
+                  total += (latency_nanos instanceof Double ? latency_nanos : 0);
+                return Math.round(total / states.size() / 10000) / 100.0;
+              `,
             },
           },
           trace_count: {
@@ -124,10 +128,14 @@ export const getLatencyTrendQuery = () => {
                     }
                     `,
                   combine_script: `
-                    def average_latency_nanos = state.total_latency / state.count;
-                    return Math.round(average_latency_nanos / 10000) / 100.0;
-                    `,
-                  reduce_script: 'return states[0]',
+                    return state.total_latency / state.count;
+                  `,
+                  reduce_script: `
+                    def total = 0.0;
+                    for (latency_nanos in states)
+                      total += (latency_nanos instanceof Double ? latency_nanos : 0);
+                    return Math.round(total / states.size() / 10000) / 100.0;
+                  `,
                 },
               },
             },

--- a/public/requests/queries/dashboard_queries.ts
+++ b/public/requests/queries/dashboard_queries.ts
@@ -31,39 +31,24 @@ export const getDashboardQuery = () => {
           size: 10000,
         },
         aggs: {
-          traces: {
-            terms: {
-              field: 'traceId',
-              order: {
-                last_updated: 'desc',
-              },
-              size: 10000,
-            },
-            aggs: {
-              duration: {
-                max: {
-                  field: 'traceGroupFields.durationInNanos',
-                },
-              },
-              last_updated: {
-                max: {
-                  field: 'traceGroupFields.endTime',
-                },
-              },
-            },
-          },
-          average_latency_nanos: {
-            avg_bucket: {
-              buckets_path: 'traces>duration',
-            },
-          },
           average_latency: {
-            bucket_script: {
-              buckets_path: {
-                count: '_count',
-                latency: 'average_latency_nanos.value',
-              },
-              script: 'Math.round(params.latency / 10000) / 100.0',
+            scripted_metric: {
+              init_script: 'state.map = [:]; state.total_latency = 0.0; state.count = 0.0;',
+              map_script: `
+                if (doc.containsKey('traceGroupFields.durationInNanos') && !doc['traceGroupFields.durationInNanos'].empty) {
+                  def id = doc['traceId'].value;
+                  if (!state.map.containsKey(id)) {
+                    state.map[id] = true;
+                    state.count++;
+                    state.total_latency += doc['traceGroupFields.durationInNanos'].value;
+                  }
+                }
+                `,
+              combine_script: `
+                def average_latency_nanos = state.total_latency / state.count;
+                return Math.round(average_latency_nanos / 10000) / 100.0;
+                `,
+              reduce_script: 'return states[0]',
             },
           },
           trace_count: {
@@ -167,7 +152,7 @@ export const getLatencyTrendQuery = () => {
     },
   };
   return query;
-}
+};
 
 export const getDashboardTraceGroupPercentiles = () => {
   return {

--- a/public/requests/services_request_handler.ts
+++ b/public/requests/services_request_handler.ts
@@ -128,18 +128,20 @@ export const handleServiceMapRequest = async (http, DSL, items?, setItems?, curr
   });
 
   if (currService) {
-    const traces = await handleDslRequest(http, DSL, getRelatedServicesQuery(currService))
+    await handleDslRequest(http, DSL, getRelatedServicesQuery(currService))
       .then((response) =>
         response.aggregations.traces.buckets.filter((bucket) => bucket.service.doc_count > 0)
       )
+      .then((traces) => {
+        const maxNumServices = Object.keys(map).length;
+        const relatedServices = new Set<string>();
+        for (let i = 0; i < traces.length; i++) {
+          traces[i].all_services.buckets.map((bucket) => relatedServices.add(bucket.key));
+          if (relatedServices.size === maxNumServices) break;
+        }
+        map[currService].relatedServices = [...relatedServices];
+      })
       .catch((error) => console.error(error));
-    const maxNumServices = Object.keys(map).length;
-    const relatedServices = new Set<string>();
-    for (let i = 0; i < traces.length; i++) {
-      traces[i].all_services.buckets.map((bucket) => relatedServices.add(bucket.key));
-      if (relatedServices.size === maxNumServices) break;
-    }
-    map[currService].relatedServices = [...relatedServices];
   }
 
   if (setItems) setItems(map);


### PR DESCRIPTION
*Issue #, if available:*
- #40 
- https://github.com/opensearch-project/trace-analytics/issues/21

*Description of changes:*
To calculate trace group average latency, dashboard previously aggregate on `traceGroup` first, then within each trace group, aggregate again on `traceId` (required because of https://github.com/opendistro-for-elasticsearch/trace-analytics/issues/27#issuecomment-805238691) and sample 1 `traceGroupFields.durationInNanos` from each trace bucket towards trace group average latency.

The implementation leads to two problems:
- `terms aggregation` has a limit on bucket size of 10000, thus the metric is calculated based on most recent 10000 traces only
- number of buckets grows quickly and we'll soon exceed the default `max_bucket` limit of 65536 for entire query

So we are changing the DSL implementation to use `scripted metrics` by maintaining a hashmap to guarantee uniqueness. This doesn't have the above problems, but needs more testing on performance.

 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 