### PR TITLE
Add spans flyout and data grid to view/filter attributes, switch filters to sessionstorage

### DIFF
--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -51,33 +51,33 @@ export const TraceAnalyticsApp = ({
   navigation,
 }: TraceAnalyticsAppDeps) => {
   const [indicesExist, setIndicesExist] = useState(true);
-  const storedFilters = localStorage.getItem('TraceAnalyticsFilters');
-  const [query, setQuery] = useState<string>(localStorage.getItem('TraceAnalyticsQuery') || '');
+  const storedFilters = sessionStorage.getItem('TraceAnalyticsFilters');
+  const [query, setQuery] = useState<string>(sessionStorage.getItem('TraceAnalyticsQuery') || '');
   const [filters, setFilters] = useState<FilterType[]>(
     storedFilters ? JSON.parse(storedFilters) : []
   );
   const [startTime, setStartTime] = useState<string>(
-    localStorage.getItem('TraceAnalyticsStartTime') || 'now-5m'
+    sessionStorage.getItem('TraceAnalyticsStartTime') || 'now-5m'
   );
   const [endTime, setEndTime] = useState<string>(
-    localStorage.getItem('TraceAnalyticsEndTime') || 'now'
+    sessionStorage.getItem('TraceAnalyticsEndTime') || 'now'
   );
 
   const setFiltersWithStorage = (newFilters: FilterType[]) => {
     setFilters(newFilters);
-    localStorage.setItem('TraceAnalyticsFilters', JSON.stringify(newFilters));
+    sessionStorage.setItem('TraceAnalyticsFilters', JSON.stringify(newFilters));
   };
   const setQueryWithStorage = (newQuery: string) => {
     setQuery(newQuery);
-    localStorage.setItem('TraceAnalyticsQuery', newQuery);
+    sessionStorage.setItem('TraceAnalyticsQuery', newQuery);
   };
   const setStartTimeWithStorage = (newStartTime: string) => {
     setStartTime(newStartTime);
-    localStorage.setItem('TraceAnalyticsStartTime', newStartTime);
+    sessionStorage.setItem('TraceAnalyticsStartTime', newStartTime);
   };
   const setEndTimeWithStorage = (newEndTime: string) => {
     setEndTime(newEndTime);
-    localStorage.setItem('TraceAnalyticsEndTime', newEndTime);
+    sessionStorage.setItem('TraceAnalyticsEndTime', newEndTime);
   };
 
   useEffect(() => {

--- a/public/components/common/plots/plt.tsx
+++ b/public/components/common/plots/plt.tsx
@@ -21,6 +21,7 @@ interface PltProps {
   data: Plotly.Data[];
   layout?: Partial<Plotly.Layout>;
   onHoverHandler?: (event: Readonly<Plotly.PlotMouseEvent>) => void;
+  onUnhoverHandler?: (event: Readonly<Plotly.PlotMouseEvent>) => void;
   onClickHandler?: (event: Readonly<Plotly.PlotMouseEvent>) => void;
   height?: string;
 }
@@ -33,6 +34,7 @@ export function Plt(props: PltProps) {
       data={props.data}
       style={{ width: '100%', height: props.height || '100%' }}
       onHover={props.onHoverHandler}
+      onUnhover={props.onUnhoverHandler}
       onClick={props.onClickHandler}
       useResizeHandler
       config={{ displayModeBar: false }}

--- a/public/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
+++ b/public/components/services/__tests__/__snapshots__/service_view.test.tsx.snap
@@ -222,6 +222,29 @@ exports[`Service view component renders service view 1`] = `
         serviceMap={Object {}}
         setIdSelected={[Function]}
       />
+      <EuiSpacer />
+      <EuiPanel>
+        <PanelTitle
+          title="Spans"
+          totalItems={0}
+        />
+        <EuiHorizontalRule
+          margin="m"
+        />
+        <div>
+          <SpanDetailTable
+            DSL={Object {}}
+            hiddenColumns={
+              Array [
+                "serviceName",
+              ]
+            }
+            http={[MockFunction]}
+            openFlyout={[Function]}
+            setTotal={[Function]}
+          />
+        </div>
+      </EuiPanel>
     </EuiPageBody>
   </EuiPage>
 </Fragment>

--- a/public/components/services/service_view.tsx
+++ b/public/components/services/service_view.tsx
@@ -359,7 +359,7 @@ export function ServiceView(props: ServiceViewProps) {
               </>
             )}
             <EuiHorizontalRule margin="m" />
-            <div style={{ overflowY: 'auto', maxHeight: 500 }}>{spanDetailTable}</div>
+            <div>{spanDetailTable}</div>
           </EuiPanel>
           {!!currentSpan && (
             <SpanDetailFlyout

--- a/public/components/services/service_view.tsx
+++ b/public/components/services/service_view.tsx
@@ -14,6 +14,7 @@
  */
 
 import {
+  EuiBadge,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -36,6 +37,8 @@ import { CoreDeps } from '../app';
 import { filtersToDsl, PanelTitle, renderDatePicker, SearchBarProps } from '../common';
 import { FilterType } from '../common/filters/filters';
 import { ServiceMap, ServiceObject } from '../common/plots/service_map';
+import { SpanDetailFlyout } from '../traces/span_detail_flyout';
+import { SpanDetailTable } from '../traces/span_detail_table';
 
 interface ServiceViewProps extends SearchBarProps, CoreDeps {
   serviceName: string;
@@ -215,6 +218,114 @@ export function ServiceView(props: ServiceViewProps) {
     [props.filters]
   );
 
+  const [currentSpan, setCurrentSpan] = useState('');
+  const storedFilters = sessionStorage.getItem('TraceAnalyticsSpanFilters');
+  const [spanFilters, setSpanFilters] = useState<Array<{ field: string; value: any }>>(
+    storedFilters ? JSON.parse(storedFilters) : []
+  );
+  const [DSL, setDSL] = useState<any>({});
+
+  const setSpanFiltersWithStorage = (newFilters: Array<{ field: string; value: any }>) => {
+    setSpanFilters(newFilters);
+    sessionStorage.setItem('TraceAnalyticsSpanFilters', JSON.stringify(newFilters));
+  };
+
+  useEffect(() => {
+    const DSL = filtersToDsl(props.filters, props.query, props.startTime, props.endTime);
+    DSL.query.bool.must.push({
+      term: {
+        serviceName: props.serviceName,
+      },
+    });
+    spanFilters.map(({ field, value }) => {
+      if (value != null) {
+        DSL.query.bool.must.push({
+          term: {
+            [field]: value,
+          },
+        });
+      }
+    });
+    setDSL(DSL);
+  }, [props.startTime, props.endTime, props.serviceName, spanFilters]);
+
+  const addSpanFilter = (field: string, value: any) => {
+    const newFilters = [...spanFilters];
+    const index = newFilters.findIndex(({ field: filterField }) => field === filterField);
+    if (index === -1) {
+      newFilters.push({ field, value });
+    } else {
+      newFilters.splice(index, 1, { field, value });
+    }
+    setSpanFiltersWithStorage(newFilters);
+  };
+
+  const removeSpanFilter = (field: string) => {
+    const newFilters = [...spanFilters];
+    const index = newFilters.findIndex(({ field: filterField }) => field === filterField);
+    if (index !== -1) {
+      newFilters.splice(index, 1);
+      setSpanFiltersWithStorage(newFilters);
+    }
+  };
+
+  const spanFiltersToDSL = () => {
+    const DSL: any = {
+      query: {
+        bool: {
+          must: [
+            {
+              term: {
+                serviceName: props.serviceName,
+              },
+            },
+          ],
+          filter: [],
+          should: [],
+          must_not: [],
+        },
+      },
+    };
+    spanFilters.map(({ field, value }) => {
+      if (value != null) {
+        DSL.query.bool.must.push({
+          term: {
+            [field]: value,
+          },
+        });
+      }
+    });
+    return DSL;
+  };
+  const renderFilters = useMemo(() => {
+    return spanFilters.map(({ field, value }) => (
+      <EuiFlexItem grow={false} key={`span-filter-badge-${field}`}>
+        <EuiBadge
+          iconType="cross"
+          iconSide="right"
+          iconOnClick={() => removeSpanFilter(field)}
+          iconOnClickAriaLabel="remove current filter"
+        >
+          {`${field}: ${value}`}
+        </EuiBadge>
+      </EuiFlexItem>
+    ));
+  }, [spanFilters]);
+
+  const [total, setTotal] = useState(0);
+  const spanDetailTable = useMemo(
+    () => (
+      <SpanDetailTable
+        http={props.http}
+        hiddenColumns={['serviceName']}
+        DSL={DSL}
+        openFlyout={(spanId: string) => setCurrentSpan(spanId)}
+        setTotal={setTotal}
+      />
+    ),
+    [DSL, setCurrentSpan]
+  );
+
   return (
     <>
       <EuiPage>
@@ -236,6 +347,29 @@ export function ServiceView(props: ServiceViewProps) {
             setIdSelected={setServiceMapIdSelected}
             currService={props.serviceName}
           />
+          <EuiSpacer />
+          <EuiPanel>
+            <PanelTitle title="Spans" totalItems={total} />
+            {spanFilters.length > 0 && (
+              <>
+                <EuiSpacer size="s" />
+                <EuiFlexGroup gutterSize="s" wrap>
+                  {renderFilters}
+                </EuiFlexGroup>
+              </>
+            )}
+            <EuiHorizontalRule margin="m" />
+            <div style={{ overflowY: 'auto', maxHeight: 500 }}>{spanDetailTable}</div>
+          </EuiPanel>
+          {!!currentSpan && (
+            <SpanDetailFlyout
+              http={props.http}
+              spanId={currentSpan}
+              isFlyoutVisible={!!currentSpan}
+              closeFlyout={() => setCurrentSpan('')}
+              addSpanFilter={addSpanFilter}
+            />
+          )}
         </EuiPageBody>
       </EuiPage>
     </>

--- a/public/components/services/service_view.tsx
+++ b/public/components/services/service_view.tsx
@@ -269,34 +269,6 @@ export function ServiceView(props: ServiceViewProps) {
     }
   };
 
-  const spanFiltersToDSL = () => {
-    const DSL: any = {
-      query: {
-        bool: {
-          must: [
-            {
-              term: {
-                serviceName: props.serviceName,
-              },
-            },
-          ],
-          filter: [],
-          should: [],
-          must_not: [],
-        },
-      },
-    };
-    spanFilters.map(({ field, value }) => {
-      if (value != null) {
-        DSL.query.bool.must.push({
-          term: {
-            [field]: value,
-          },
-        });
-      }
-    });
-    return DSL;
-  };
   const renderFilters = useMemo(() => {
     return spanFilters.map(({ field, value }) => (
       <EuiFlexItem grow={false} key={`span-filter-badge-${field}`}>

--- a/public/components/services/service_view.tsx
+++ b/public/components/services/service_view.tsx
@@ -67,7 +67,7 @@ export function ServiceView(props: ServiceViewProps) {
 
   useEffect(() => {
     if (!redirect) refresh();
-  }, [props.startTime, props.endTime]);
+  }, [props.startTime, props.endTime, props.serviceName]);
 
   const refresh = () => {
     const DSL = filtersToDsl(props.filters, props.query, props.startTime, props.endTime);
@@ -126,7 +126,7 @@ export function ServiceView(props: ServiceViewProps) {
                   {fields.connected_services
                     ? fields.connected_services
                         .map((service: string) => (
-                          <EuiLink href={`#/services/${service}`} target="_blank" key={service}>
+                          <EuiLink href={`#/services/${service}`} key={service}>
                             {service}
                           </EuiLink>
                         ))

--- a/public/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/span_detail_panel.test.tsx.snap
@@ -65,23 +65,252 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
     <div
       className="euiPanel euiPanel--paddingMedium"
     >
-      <PanelTitle
-        title="Span detail"
-      >
-        <EuiText
-          size="m"
+      <EuiFlexGroup>
+        <div
+          className="euiFlexGroup euiFlexGroup--gutterLarge euiFlexGroup--directionRow euiFlexGroup--responsive"
         >
-          <div
-            className="euiText euiText--medium"
-          >
-            <span
-              className="panel-title"
+          <EuiFlexItem>
+            <div
+              className="euiFlexItem"
             >
-              Span detail
-            </span>
-          </div>
-        </EuiText>
-      </PanelTitle>
+              <PanelTitle
+                title="Spans"
+                totalItems={0}
+              >
+                <EuiText
+                  size="m"
+                >
+                  <div
+                    className="euiText euiText--medium"
+                  >
+                    <span
+                      className="panel-title"
+                    >
+                      Spans
+                    </span>
+                    <span
+                      className="panel-title-count"
+                    >
+                       (0)
+                    </span>
+                  </div>
+                </EuiText>
+              </PanelTitle>
+            </div>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <div
+              className="euiFlexItem euiFlexItem--flexGrowZero"
+            >
+              <EuiButtonGroup
+                idSelected="timeline"
+                legend="Select view of spans"
+                onChange={[Function]}
+                options={
+                  Array [
+                    Object {
+                      "id": "timeline",
+                      "label": "Timeline",
+                    },
+                    Object {
+                      "id": "span_list",
+                      "label": "Span list",
+                    },
+                  ]
+                }
+              >
+                <fieldset
+                  className="euiButtonGroup__fieldset"
+                >
+                  <EuiScreenReaderOnly>
+                    <legend
+                      className="euiScreenReaderOnly"
+                    >
+                      Select view of spans
+                    </legend>
+                  </EuiScreenReaderOnly>
+                  <div
+                    className="euiButtonGroup euiButtonGroup--s"
+                  >
+                    <EuiButtonToggle
+                      className="euiButtonGroup__button euiButtonGroup__button--selected"
+                      color="text"
+                      fill={true}
+                      id="timeline"
+                      isSelected={true}
+                      key="0"
+                      label="Timeline"
+                      onChange={[Function]}
+                      size="s"
+                      toggleClassName="euiButtonGroup__toggle"
+                      type="single"
+                    >
+                      <EuiToggle
+                        checked={true}
+                        className="euiButtonToggle__wrapper euiButtonGroup__toggle"
+                        inputClassName="euiButtonToggle__input"
+                        label="Timeline"
+                        onChange={[Function]}
+                        title="Timeline"
+                        type="single"
+                      >
+                        <div
+                          className="euiToggle euiToggle--checked euiButtonToggle__wrapper euiButtonGroup__toggle"
+                        >
+                          <input
+                            aria-label="Timeline"
+                            checked={true}
+                            className="euiToggle__input euiButtonToggle__input"
+                            onChange={[Function]}
+                            title="Timeline"
+                            type="radio"
+                          />
+                          <EuiButton
+                            className="euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected"
+                            color="text"
+                            fill={true}
+                            id="timeline"
+                            size="s"
+                            tabIndex={-1}
+                          >
+                            <EuiButtonDisplay
+                              className="euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected"
+                              color="text"
+                              disabled={false}
+                              element="button"
+                              fill={true}
+                              id="timeline"
+                              isDisabled={false}
+                              size="s"
+                              tabIndex={-1}
+                              type="button"
+                            >
+                              <button
+                                className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button euiButtonGroup__button--selected euiButton--fill"
+                                disabled={false}
+                                id="timeline"
+                                tabIndex={-1}
+                                type="button"
+                              >
+                                <EuiButtonContent
+                                  className="euiButton__content"
+                                  iconSide="left"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButton__text",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Timeline
+                                    </span>
+                                  </span>
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonDisplay>
+                          </EuiButton>
+                        </div>
+                      </EuiToggle>
+                    </EuiButtonToggle>
+                    <EuiButtonToggle
+                      className="euiButtonGroup__button"
+                      color="text"
+                      fill={false}
+                      id="span_list"
+                      isSelected={false}
+                      key="1"
+                      label="Span list"
+                      onChange={[Function]}
+                      size="s"
+                      toggleClassName="euiButtonGroup__toggle"
+                      type="single"
+                    >
+                      <EuiToggle
+                        checked={false}
+                        className="euiButtonToggle__wrapper euiButtonGroup__toggle"
+                        inputClassName="euiButtonToggle__input"
+                        label="Span list"
+                        onChange={[Function]}
+                        title="Span list"
+                        type="single"
+                      >
+                        <div
+                          className="euiToggle euiButtonToggle__wrapper euiButtonGroup__toggle"
+                        >
+                          <input
+                            aria-label="Span list"
+                            checked={false}
+                            className="euiToggle__input euiButtonToggle__input"
+                            onChange={[Function]}
+                            title="Span list"
+                            type="radio"
+                          />
+                          <EuiButton
+                            className="euiButtonToggle euiButtonGroup__button"
+                            color="text"
+                            fill={false}
+                            id="span_list"
+                            size="s"
+                            tabIndex={-1}
+                          >
+                            <EuiButtonDisplay
+                              className="euiButtonToggle euiButtonGroup__button"
+                              color="text"
+                              disabled={false}
+                              element="button"
+                              fill={false}
+                              id="span_list"
+                              isDisabled={false}
+                              size="s"
+                              tabIndex={-1}
+                              type="button"
+                            >
+                              <button
+                                className="euiButton euiButton--text euiButton--small euiButtonToggle euiButtonGroup__button"
+                                disabled={false}
+                                id="span_list"
+                                tabIndex={-1}
+                                type="button"
+                              >
+                                <EuiButtonContent
+                                  className="euiButton__content"
+                                  iconSide="left"
+                                  textProps={
+                                    Object {
+                                      "className": "euiButton__text",
+                                    }
+                                  }
+                                >
+                                  <span
+                                    className="euiButtonContent euiButton__content"
+                                  >
+                                    <span
+                                      className="euiButton__text"
+                                    >
+                                      Span list
+                                    </span>
+                                  </span>
+                                </EuiButtonContent>
+                              </button>
+                            </EuiButtonDisplay>
+                          </EuiButton>
+                        </div>
+                      </EuiToggle>
+                    </EuiButtonToggle>
+                  </div>
+                </fieldset>
+              </EuiButtonGroup>
+            </div>
+          </EuiFlexItem>
+        </div>
+      </EuiFlexGroup>
       <EuiHorizontalRule
         margin="m"
       >
@@ -98,53 +327,10 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
         }
       >
         <Plt
-          data={
-            Array [
-              Object {
-                "hoverinfo": "none",
-                "marker": Object {
-                  "color": "rgba(0, 0, 0, 0)",
-                },
-                "orientation": "h",
-                "showlegend": false,
-                "type": "bar",
-                "width": 0.4,
-                "x": Array [
-                  0,
-                ],
-                "y": Array [
-                  "inventory <br>HTTP GET 4dec6080-61af-11eb-aee3-ef2f84ffa4a2",
-                ],
-              },
-              Object {
-                "hovertemplate": "%{x}<extra></extra>",
-                "marker": Object {
-                  "color": "#7492e7",
-                },
-                "orientation": "h",
-                "text": Array [
-                  "Error",
-                ],
-                "textfont": Object {
-                  "color": Array [
-                    "#c14125",
-                  ],
-                },
-                "textposition": "outside",
-                "type": "bar",
-                "width": 0.4,
-                "x": Array [
-                  19.91,
-                ],
-                "y": Array [
-                  "inventory <br>HTTP GET 4dec6080-61af-11eb-aee3-ef2f84ffa4a2",
-                ],
-              },
-            ]
-          }
+          data={Array []}
           layout={
             Object {
-              "height": 110,
+              "height": 60,
               "margin": Object {
                 "b": 30,
                 "l": 260,
@@ -156,7 +342,7 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                 "color": "#91989c",
                 "range": Array [
                   0,
-                  23.892,
+                  0,
                 ],
                 "showline": true,
                 "side": "top",
@@ -164,15 +350,14 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
               },
               "yaxis": Object {
                 "showgrid": false,
-                "ticktext": Array [
-                  "inventory <br>HTTP GET ",
-                ],
-                "tickvals": Array [
-                  "inventory <br>HTTP GET 4dec6080-61af-11eb-aee3-ef2f84ffa4a2",
-                ],
+                "ticktext": Array [],
+                "tickvals": Array [],
               },
             }
           }
+          onClickHandler={[Function]}
+          onHoverHandler={[Function]}
+          onUnhoverHandler={[Function]}
         >
           <PlotlyComponent
             config={
@@ -180,56 +365,13 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                 "displayModeBar": false,
               }
             }
-            data={
-              Array [
-                Object {
-                  "hoverinfo": "none",
-                  "marker": Object {
-                    "color": "rgba(0, 0, 0, 0)",
-                  },
-                  "orientation": "h",
-                  "showlegend": false,
-                  "type": "bar",
-                  "width": 0.4,
-                  "x": Array [
-                    0,
-                  ],
-                  "y": Array [
-                    "inventory <br>HTTP GET 4dec6080-61af-11eb-aee3-ef2f84ffa4a2",
-                  ],
-                },
-                Object {
-                  "hovertemplate": "%{x}<extra></extra>",
-                  "marker": Object {
-                    "color": "#7492e7",
-                  },
-                  "orientation": "h",
-                  "text": Array [
-                    "Error",
-                  ],
-                  "textfont": Object {
-                    "color": Array [
-                      "#c14125",
-                    ],
-                  },
-                  "textposition": "outside",
-                  "type": "bar",
-                  "width": 0.4,
-                  "x": Array [
-                    19.91,
-                  ],
-                  "y": Array [
-                    "inventory <br>HTTP GET 4dec6080-61af-11eb-aee3-ef2f84ffa4a2",
-                  ],
-                },
-              ]
-            }
+            data={Array []}
             debug={false}
             layout={
               Object {
                 "autosize": true,
                 "barmode": "stack",
-                "height": 110,
+                "height": 60,
                 "hovermode": "closest",
                 "legend": Object {
                   "orientation": "h",
@@ -247,7 +389,7 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                   "color": "#91989c",
                   "range": Array [
                     0,
-                    23.892,
+                    0,
                   ],
                   "showline": true,
                   "side": "top",
@@ -255,15 +397,14 @@ exports[`Service breakdown panel component renders service breakdown panel 1`] =
                 },
                 "yaxis": Object {
                   "showgrid": false,
-                  "ticktext": Array [
-                    "inventory <br>HTTP GET ",
-                  ],
-                  "tickvals": Array [
-                    "inventory <br>HTTP GET 4dec6080-61af-11eb-aee3-ef2f84ffa4a2",
-                  ],
+                  "ticktext": Array [],
+                  "tickvals": Array [],
                 },
               }
             }
+            onClick={[Function]}
+            onHover={[Function]}
+            onUnhover={[Function]}
             style={
               Object {
                 "height": "100%",

--- a/public/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/trace_view.test.tsx.snap
@@ -108,7 +108,9 @@ exports[`Trace view component renders trace view 1`] = `
                 <EuiText
                   className="overview-content"
                   size="s"
-                />
+                >
+                  -
+                </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
@@ -127,13 +129,9 @@ exports[`Trace view component renders trace view 1`] = `
           grow={7}
         >
           <SpanDetailPanel
-            data={
-              Object {
-                "gantt": Array [],
-                "ganttMaxX": 0,
-                "table": Array [],
-              }
-            }
+            colorMap={Object {}}
+            http={[MockFunction]}
+            traceId="test"
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
+++ b/public/components/traces/__tests__/__snapshots__/traces_table.test.tsx.snap
@@ -1581,7 +1581,7 @@ exports[`Traces table component renders traces table 1`] = `
                               <div
                                 className="euiTableCellContent euiTableCellContent--alignRight euiTableCellContent--overflowingContent"
                               >
-                                Yes
+                                No
                               </div>
                             </td>
                           </EuiTableRowCell>

--- a/public/components/traces/flyout_list_item.tsx
+++ b/public/components/traces/flyout_list_item.tsx
@@ -34,7 +34,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
   const [hover, setHover] = useState(false);
 
   const descriptionComponent =
-    props.description && props.description !== '-' ? (
+    props.description !== '-' ? (
       <EuiFlexGroup gutterSize="none">
         <EuiFlexItem>
           <EuiText size="s" style={{ wordBreak: 'break-all', wordWrap: 'break-word', whiteSpace: 'pre-line' }}>
@@ -48,7 +48,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
                 aria-label="span-flyout-filter-icon"
                 iconType="filter"
                 onClick={props.addSpanFilter}
-                style={{ marginBottom: -8, marginTop: -2 }}
+                style={{ margin: -5 }}
               />
             </EuiToolTip>
           )}

--- a/public/components/traces/flyout_list_item.tsx
+++ b/public/components/traces/flyout_list_item.tsx
@@ -35,7 +35,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
     props.description && props.description !== '-' ? (
       <EuiFlexGroup gutterSize="none">
         <EuiFlexItem>
-          <EuiText size="s" style={{ wordWrap: 'break-word' }}>
+          <EuiText size="s" style={{ wordBreak: 'break-all', wordWrap: 'break-word' }}>
             <b>{props.description}</b>
           </EuiText>
         </EuiFlexItem>
@@ -50,7 +50,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
         </EuiFlexItem>
       </EuiFlexGroup>
     ) : (
-      <EuiText size="s" style={{ wordWrap: 'break-word' }}>
+      <EuiText size="s" style={{ wordBreak: 'break-all', wordWrap: 'break-word' }}>
         <b>{props.description}</b>
       </EuiText>
     );
@@ -61,7 +61,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
           listItems={[
             {
               title: (
-                <EuiText size="s" color="subdued" style={{ wordWrap: 'break-word' }}>
+                <EuiText size="s" color="subdued" style={{ wordBreak: 'break-all', wordWrap: 'break-word' }}>
                   {props.title}
                 </EuiText>
               ),

--- a/public/components/traces/flyout_list_item.tsx
+++ b/public/components/traces/flyout_list_item.tsx
@@ -37,7 +37,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
     props.description && props.description !== '-' ? (
       <EuiFlexGroup gutterSize="none">
         <EuiFlexItem>
-          <EuiText size="s" style={{ wordBreak: 'break-all', wordWrap: 'break-word' }}>
+          <EuiText size="s" style={{ wordBreak: 'break-all', wordWrap: 'break-word', whiteSpace: 'pre-line' }}>
             <b>{props.description}</b>
           </EuiText>
         </EuiFlexItem>
@@ -55,7 +55,7 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
         </EuiFlexItem>
       </EuiFlexGroup>
     ) : (
-      <EuiText size="s" style={{ wordBreak: 'break-all', wordWrap: 'break-word' }}>
+      <EuiText size="s" style={{ wordBreak: 'break-all', wordWrap: 'break-word', whiteSpace: 'pre-line' }}>
         <b>{props.description}</b>
       </EuiText>
     );

--- a/public/components/traces/flyout_list_item.tsx
+++ b/public/components/traces/flyout_list_item.tsx
@@ -20,12 +20,14 @@ import {
   EuiFlexItem,
   EuiSpacer,
   EuiText,
+  EuiToolTip,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 
 interface FlyoutListItemProps {
   title: React.ReactNode;
   description: React.ReactNode;
+  addSpanFilter: () => void;
 }
 
 export function FlyoutListItem(props: FlyoutListItemProps) {
@@ -41,11 +43,14 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           {hover && (
-            <EuiButtonIcon
-              aria-label="span-flyout-filter-icon"
-              iconType="filter"
-              style={{ marginBottom: -8, marginTop: -2 }}
-            />
+            <EuiToolTip position="top" content="Filter spans on this value">
+              <EuiButtonIcon
+                aria-label="span-flyout-filter-icon"
+                iconType="filter"
+                onClick={props.addSpanFilter}
+                style={{ marginBottom: -8, marginTop: -2 }}
+              />
+            </EuiToolTip>
           )}
         </EuiFlexItem>
       </EuiFlexGroup>
@@ -61,7 +66,11 @@ export function FlyoutListItem(props: FlyoutListItemProps) {
           listItems={[
             {
               title: (
-                <EuiText size="s" color="subdued" style={{ wordBreak: 'break-all', wordWrap: 'break-word' }}>
+                <EuiText
+                  size="s"
+                  color="subdued"
+                  style={{ wordBreak: 'break-all', wordWrap: 'break-word' }}
+                >
                   {props.title}
                 </EuiText>
               ),

--- a/public/components/traces/flyout_list_item.tsx
+++ b/public/components/traces/flyout_list_item.tsx
@@ -1,0 +1,79 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  EuiButtonIcon,
+  EuiDescriptionList,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+
+interface FlyoutListItemProps {
+  title: React.ReactNode;
+  description: React.ReactNode;
+}
+
+export function FlyoutListItem(props: FlyoutListItemProps) {
+  const [hover, setHover] = useState(false);
+
+  const descriptionComponent =
+    props.description && props.description !== '-' ? (
+      <EuiFlexGroup gutterSize="none">
+        <EuiFlexItem>
+          <EuiText size="s" style={{ wordWrap: 'break-word' }}>
+            <b>{props.description}</b>
+          </EuiText>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          {hover && (
+            <EuiButtonIcon
+              aria-label="span-flyout-filter-icon"
+              iconType="filter"
+              style={{ marginBottom: -8, marginTop: -2 }}
+            />
+          )}
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    ) : (
+      <EuiText size="s" style={{ wordWrap: 'break-word' }}>
+        <b>{props.description}</b>
+      </EuiText>
+    );
+  return (
+    <>
+      <div onMouseOver={() => setHover(true)} onMouseLeave={() => setHover(false)}>
+        <EuiDescriptionList
+          listItems={[
+            {
+              title: (
+                <EuiText size="s" color="subdued" style={{ wordWrap: 'break-word' }}>
+                  {props.title}
+                </EuiText>
+              ),
+              description: descriptionComponent,
+            },
+          ]}
+          type="column"
+          align="center"
+          compressed
+        />
+      </div>
+      <EuiSpacer size="s" />
+    </>
+  );
+}

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -129,7 +129,14 @@ export function SpanDetailFlyout(props: {
         if (isANull) return 1;
         return -1;
       })
-      .map((key) => getListItem(key, key, _.isEmpty(span[key]) ? '-' : span[key]));
+      .map((key) => {
+        if (_.isEmpty(span[key])) return getListItem(key, key, '-');
+        let value = span[key];
+        if (typeof value === 'object')
+          value = JSON.stringify(value, null, 2).replace(/ /g, '\u00a0');
+        return getListItem(key, key, value);
+      });
+
     return (
       <>
         <EuiText size="m">

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -122,7 +122,13 @@ export function SpanDetailFlyout(props: {
     ]);
     const attributesList = Object.keys(span)
       .filter((key) => !ignoredKeys.has(key))
-      .sort()
+      .sort((keyA, keyB) => {
+        const isANull = _.isEmpty(span[keyA]);
+        const isBNull = _.isEmpty(span[keyB]);
+        if ((isANull && isBNull) || (!isANull && !isBNull)) return keyA < keyB ? -1 : 1;
+        if (isANull) return 1;
+        return -1;
+      })
       .map((key) => getListItem(key, key, _.isEmpty(span[key]) ? '-' : span[key]));
     return (
       <>

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -91,7 +91,7 @@ export function SpanDetailFlyout(props: {
       ),
       getListItem(
         'parentSpanId',
-        'Parent Span ID',
+        'Parent span ID',
         span.parentSpanId ? (
           <EuiFlexGroup gutterSize="xs" style={{ marginTop: -4, marginBottom: -4 }}>
             <EuiFlexItem grow={false}>
@@ -200,7 +200,7 @@ export function SpanDetailFlyout(props: {
       <EuiFlyout onClose={props.closeFlyout} size="s">
         <EuiFlyoutHeader hasBorder>
           <EuiTitle>
-            <h2>Span Detail</h2>
+            <h2>Span detail</h2>
           </EuiTitle>
         </EuiFlyoutHeader>
         <EuiFlyoutBody>{renderContent()}</EuiFlyoutBody>

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -116,7 +116,17 @@ export function SpanDetailFlyout(props: {
       ),
       getListItem('startTime', 'Start time', moment(span.startTime).format(DATE_FORMAT)),
       getListItem('endTime', 'End time', moment(span.endTime).format(DATE_FORMAT)),
-      getListItem('status.code', 'Errors', span['status.code'] === 2 ? 'Yes' : 'No'),
+      getListItem(
+        'status.code',
+        'Errors',
+        span['status.code'] === 2 ? (
+          <EuiText color="danger" size="s" style={{fontWeight: 700}}>
+            Yes
+          </EuiText>
+        ) : (
+          'No'
+        )
+      ),
     ];
     const ignoredKeys = new Set([
       'spanId',

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -40,26 +40,33 @@ export function SpanDetailFlyout(props: {
   spanId: string;
   isFlyoutVisible: boolean;
   closeFlyout: () => void;
+  addSpanFilter: (field: string, value: any) => void;
 }) {
   const [span, setSpan] = useState<any>({});
+
   useEffect(() => {
     handleSpansFlyoutRequest(props.http, props.spanId, setSpan);
   }, [props.spanId]);
 
-  const getListItem = (title: React.ReactNode, description: React.ReactNode) => (
-    <FlyoutListItem title={title} description={description} key={`list-item-${title}`} />
-  );
+  const getListItem = (field: string, title: React.ReactNode, description: React.ReactNode) => {
+    return (
+      <FlyoutListItem
+        title={title}
+        description={description}
+        key={`list-item-${title}`}
+        addSpanFilter={() => props.addSpanFilter(field, span[field])}
+      />
+    );
+  };
 
   const renderContent = () => {
     if (!span || _.isEmpty(span)) return '-';
     const overviewList = [
       getListItem(
+        'spanId',
         'Span ID',
         span.spanId ? (
-          <EuiFlexGroup
-            gutterSize="xs"
-            style={{ marginTop: -4, marginBottom: -4 }}
-          >
+          <EuiFlexGroup gutterSize="xs" style={{ marginTop: -4, marginBottom: -4 }}>
             <EuiFlexItem grow={false}>
               <EuiCopy textToCopy={span.spanId}>
                 {(copy) => (
@@ -74,12 +81,10 @@ export function SpanDetailFlyout(props: {
         )
       ),
       getListItem(
+        'parentSpanId',
         'Parent Span ID',
         span.parentSpanId ? (
-          <EuiFlexGroup
-            gutterSize="xs"
-            style={{ marginTop: -4, marginBottom: -4 }}
-          >
+          <EuiFlexGroup gutterSize="xs" style={{ marginTop: -4, marginBottom: -4 }}>
             <EuiFlexItem grow={false}>
               <EuiCopy textToCopy={span.parentSpanId}>
                 {(copy) => (
@@ -93,12 +98,12 @@ export function SpanDetailFlyout(props: {
           '-'
         )
       ),
-      getListItem('Service', span.serviceName || '-'),
-      getListItem('Operation', span.name || '-'),
-      getListItem('Duration', `${nanoToMilliSec(span.durationInNanos)} ms`),
-      getListItem('Start time', moment(span.startTime).format(DATE_FORMAT)),
-      getListItem('End time', moment(span.endTime).format(DATE_FORMAT)),
-      getListItem('Has error', span['status.code'] === 2 ? 'Yes' : 'No'),
+      getListItem('serviceName', 'Service', span.serviceName || '-'),
+      getListItem('name', 'Operation', span.name || '-'),
+      getListItem('durationInNanos', 'Duration', `${nanoToMilliSec(span.durationInNanos)} ms`),
+      getListItem('startTime', 'Start time', moment(span.startTime).format(DATE_FORMAT)),
+      getListItem('endTime', 'End time', moment(span.endTime).format(DATE_FORMAT)),
+      getListItem('status.code', 'Has error', span['status.code'] === 2 ? 'Yes' : 'No'),
     ];
     const ignoredKeys = new Set([
       'spanId',
@@ -118,7 +123,7 @@ export function SpanDetailFlyout(props: {
     const attributesList = Object.keys(span)
       .filter((key) => !ignoredKeys.has(key))
       .sort()
-      .map((key) => getListItem(key, _.isEmpty(span[key]) ? '-' : span[key]));
+      .map((key) => getListItem(key, key, _.isEmpty(span[key]) ? '-' : span[key]));
     return (
       <>
         <EuiText size="m">

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -58,12 +58,13 @@ export function SpanDetailFlyout(props: {
         span.spanId ? (
           <EuiFlexGroup
             gutterSize="xs"
-            alignItems="center"
             style={{ marginTop: -4, marginBottom: -4 }}
           >
             <EuiFlexItem grow={false}>
               <EuiCopy textToCopy={span.spanId}>
-                {(copy) => <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />}
+                {(copy) => (
+                  <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                )}
               </EuiCopy>
             </EuiFlexItem>
             <EuiFlexItem>{span.spanId}</EuiFlexItem>
@@ -77,12 +78,13 @@ export function SpanDetailFlyout(props: {
         span.parentSpanId ? (
           <EuiFlexGroup
             gutterSize="xs"
-            alignItems="center"
             style={{ marginTop: -4, marginBottom: -4 }}
           >
             <EuiFlexItem grow={false}>
               <EuiCopy textToCopy={span.parentSpanId}>
-                {(copy) => <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />}
+                {(copy) => (
+                  <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />
+                )}
               </EuiCopy>
             </EuiFlexItem>
             <EuiFlexItem>{span.parentSpanId}</EuiFlexItem>
@@ -115,13 +117,14 @@ export function SpanDetailFlyout(props: {
     ]);
     const attributesList = Object.keys(span)
       .filter((key) => !ignoredKeys.has(key))
+      .sort()
       .map((key) => getListItem(key, _.isEmpty(span[key]) ? '-' : span[key]));
     return (
       <>
         <EuiText size="m">
           <span className="panel-title">Overview</span>
         </EuiText>
-        <EuiSpacer size="xs" />
+        <EuiSpacer size="s" />
         {overviewList}
         <EuiSpacer size="xs" />
         <EuiHorizontalRule margin="s" />
@@ -131,7 +134,7 @@ export function SpanDetailFlyout(props: {
             <span className="panel-title-count">{` (${attributesList.length})`}</span>
           ) : null}
         </EuiText>
-        <EuiSpacer size="xs" />
+        <EuiSpacer size="s" />
         {attributesList}
       </>
     );

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -1,0 +1,152 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  EuiButtonIcon,
+  EuiCopy,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFlyout,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiHorizontalRule,
+  EuiSpacer,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import _ from 'lodash';
+import moment from 'moment';
+import React, { useEffect, useState } from 'react';
+import { CoreStart } from '../../../../../src/core/public';
+import { DATE_FORMAT } from '../../../common';
+import { handleSpansFlyoutRequest } from '../../requests/traces_request_handler';
+import { nanoToMilliSec } from '../common';
+import { FlyoutListItem } from './flyout_list_item';
+
+export function SpanDetailFlyout(props: {
+  http: CoreStart['http'];
+  spanId: string;
+  isFlyoutVisible: boolean;
+  closeFlyout: () => void;
+}) {
+  const [span, setSpan] = useState<any>({});
+  useEffect(() => {
+    handleSpansFlyoutRequest(props.http, props.spanId, setSpan);
+  }, [props.spanId]);
+
+  const getListItem = (title: React.ReactNode, description: React.ReactNode) => (
+    <FlyoutListItem title={title} description={description} key={`list-item-${title}`} />
+  );
+
+  const renderContent = () => {
+    if (!span || _.isEmpty(span)) return '-';
+    const overviewList = [
+      getListItem(
+        'Span ID',
+        span.spanId ? (
+          <EuiFlexGroup
+            gutterSize="xs"
+            alignItems="center"
+            style={{ marginTop: -4, marginBottom: -4 }}
+          >
+            <EuiFlexItem grow={false}>
+              <EuiCopy textToCopy={span.spanId}>
+                {(copy) => <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />}
+              </EuiCopy>
+            </EuiFlexItem>
+            <EuiFlexItem>{span.spanId}</EuiFlexItem>
+          </EuiFlexGroup>
+        ) : (
+          '-'
+        )
+      ),
+      getListItem(
+        'Parent Span ID',
+        span.parentSpanId ? (
+          <EuiFlexGroup
+            gutterSize="xs"
+            alignItems="center"
+            style={{ marginTop: -4, marginBottom: -4 }}
+          >
+            <EuiFlexItem grow={false}>
+              <EuiCopy textToCopy={span.parentSpanId}>
+                {(copy) => <EuiButtonIcon aria-label="copy-button" onClick={copy} iconType="copyClipboard" />}
+              </EuiCopy>
+            </EuiFlexItem>
+            <EuiFlexItem>{span.parentSpanId}</EuiFlexItem>
+          </EuiFlexGroup>
+        ) : (
+          '-'
+        )
+      ),
+      getListItem('Service', span.serviceName || '-'),
+      getListItem('Operation', span.name || '-'),
+      getListItem('Duration', `${nanoToMilliSec(span.durationInNanos)} ms`),
+      getListItem('Start time', moment(span.startTime).format(DATE_FORMAT)),
+      getListItem('End time', moment(span.endTime).format(DATE_FORMAT)),
+      getListItem('Has error', span['status.code'] === 2 ? 'Yes' : 'No'),
+    ];
+    const ignoredKeys = new Set([
+      'spanId',
+      'parentSpanId',
+      'serviceName',
+      'name',
+      'durationInNanos',
+      'startTime',
+      'endTime',
+      'status.code',
+      'traceId',
+      'traceGroup',
+      'traceGroupFields.endTime',
+      'traceGroupFields.statusCode',
+      'traceGroupFields.durationInNanos',
+    ]);
+    const attributesList = Object.keys(span)
+      .filter((key) => !ignoredKeys.has(key))
+      .map((key) => getListItem(key, _.isEmpty(span[key]) ? '-' : span[key]));
+    return (
+      <>
+        <EuiText size="m">
+          <span className="panel-title">Overview</span>
+        </EuiText>
+        <EuiSpacer size="xs" />
+        {overviewList}
+        <EuiSpacer size="xs" />
+        <EuiHorizontalRule margin="s" />
+        <EuiText size="m">
+          <span className="panel-title">Span attributes</span>
+          {attributesList.length === 0 || attributesList.length ? (
+            <span className="panel-title-count">{` (${attributesList.length})`}</span>
+          ) : null}
+        </EuiText>
+        <EuiSpacer size="xs" />
+        {attributesList}
+      </>
+    );
+  };
+
+  return (
+    <>
+      <EuiFlyout onClose={props.closeFlyout} size="s">
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle>
+            <h2>Span Detail</h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>{renderContent()}</EuiFlyoutBody>
+      </EuiFlyout>
+    </>
+  );
+}

--- a/public/components/traces/span_detail_flyout.tsx
+++ b/public/components/traces/span_detail_flyout.tsx
@@ -29,7 +29,7 @@ import {
 } from '@elastic/eui';
 import _ from 'lodash';
 import moment from 'moment';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { CoreStart } from '../../../../../src/core/public';
 import { DATE_FORMAT } from '../../../common';
 import { handleSpansFlyoutRequest } from '../../requests/traces_request_handler';
@@ -68,7 +68,7 @@ export function SpanDetailFlyout(props: {
     );
   };
 
-  const renderContent = useMemo(() => () => {
+  const renderContent = () => {
     if (!span || _.isEmpty(span)) return '-';
     const overviewList = [
       getListItem(
@@ -109,10 +109,14 @@ export function SpanDetailFlyout(props: {
       ),
       getListItem('serviceName', 'Service', span.serviceName || '-'),
       getListItem('name', 'Operation', span.name || '-'),
-      getListItem('durationInNanos', 'Duration', `${nanoToMilliSec(span.durationInNanos)} ms`),
+      getListItem(
+        'durationInNanos',
+        'Duration',
+        `${_.round(nanoToMilliSec(Math.max(0, span.durationInNanos)), 2)} ms`
+      ),
       getListItem('startTime', 'Start time', moment(span.startTime).format(DATE_FORMAT)),
       getListItem('endTime', 'End time', moment(span.endTime).format(DATE_FORMAT)),
-      getListItem('status.code', 'Has error', span['status.code'] === 2 ? 'Yes' : 'No'),
+      getListItem('status.code', 'Errors', span['status.code'] === 2 ? 'Yes' : 'No'),
     ];
     const ignoredKeys = new Set([
       'spanId',
@@ -179,7 +183,7 @@ export function SpanDetailFlyout(props: {
         {attributesList}
       </>
     );
-  }, [span]);
+  };
 
   return (
     <>

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -193,6 +193,7 @@ export function SpanDetailPanel(props: {
     () => (
       <SpanDetailTable
         http={props.http}
+        hiddenColumns={['traceId', 'traceGroup']}
         DSL={DSL}
         openFlyout={(spanId: string) => setCurrentSpan(spanId)}
       />

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -107,7 +107,7 @@ export function SpanDetailPanel(props: {
     const yTexts = yLabels.map((label) => label.substring(0, label.length - 36));
 
     return {
-      height: 25 * plotTraces.length * (2 / 3) + 60,
+      height: 25 * plotTraces.length + 60,
       width: 800,
       margin: {
         l: 260,
@@ -158,6 +158,8 @@ export function SpanDetailPanel(props: {
     ));
   }, [spanFilters]);
 
+  const [cursorStyle, setCursorStyle] = useState({});
+
   const onHover = () => {
     const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
     dragLayer.style.cursor = 'pointer';
@@ -171,7 +173,7 @@ export function SpanDetailPanel(props: {
   return (
     <>
       <EuiPanel>
-        <PanelTitle title="Span detail" totalItems={data.gantt.length / 3} />
+        <PanelTitle title="Span detail" totalItems={data.gantt.length / 2} />
         {spanFilters.length > 0 && (
           <>
             <EuiSpacer size="s" />

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -107,7 +107,7 @@ export function SpanDetailPanel(props: {
     const yTexts = yLabels.map((label) => label.substring(0, label.length - 36));
 
     return {
-      height: 25 * plotTraces.length + 60,
+      height: 25 * plotTraces.length * (2 / 3) + 60,
       width: 800,
       margin: {
         l: 260,
@@ -158,8 +158,6 @@ export function SpanDetailPanel(props: {
     ));
   }, [spanFilters]);
 
-  const [cursorStyle, setCursorStyle] = useState({});
-
   const onHover = () => {
     const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
     dragLayer.style.cursor = 'pointer';
@@ -173,7 +171,7 @@ export function SpanDetailPanel(props: {
   return (
     <>
       <EuiPanel>
-        <PanelTitle title="Span detail" totalItems={data.gantt.length / 2} />
+        <PanelTitle title="Span detail" totalItems={data.gantt.length / 3} />
         {spanFilters.length > 0 && (
           <>
             <EuiSpacer size="s" />

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -158,6 +158,18 @@ export function SpanDetailPanel(props: {
     ));
   }, [spanFilters]);
 
+  const [cursorStyle, setCursorStyle] = useState({});
+
+  const onHover = () => {
+    const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
+    dragLayer.style.cursor = 'pointer';
+  };
+
+  const onUnhover = (pr) => {
+    const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
+    dragLayer.style.cursor = '';
+  };
+
   return (
     <>
       <EuiPanel>
@@ -172,7 +184,13 @@ export function SpanDetailPanel(props: {
         )}
         <EuiHorizontalRule margin="m" />
         <div style={{ overflowY: 'auto', maxHeight: 500 }}>
-          <Plt data={data.gantt} layout={layout} onClickHandler={onClick} />
+          <Plt
+            data={data.gantt}
+            layout={layout}
+            onClickHandler={onClick}
+            onHoverHandler={onHover}
+            onUnhoverHandler={onUnhover}
+          />
         </div>
       </EuiPanel>
       {!!currentSpan && (

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -40,6 +40,7 @@ export function SpanDetailPanel(props: {
   const [spanFilters, setSpanFilters] = useState<Array<{ field: string; value: any }>>(
     storedFilters ? JSON.parse(storedFilters) : []
   );
+  const [DSL, setDSL] = useState<any>({});
 
   const setSpanFiltersWithStorage = (newFilters: Array<{ field: string; value: any }>) => {
     setSpanFilters(newFilters);
@@ -70,7 +71,13 @@ export function SpanDetailPanel(props: {
     const DSL: any = {
       query: {
         bool: {
-          must: [],
+          must: [
+            {
+              term: {
+                traceId: props.traceId,
+              },
+            },
+          ],
           filter: [],
           should: [],
           must_not: [],
@@ -96,6 +103,7 @@ export function SpanDetailPanel(props: {
   const refresh = _.debounce(() => {
     if (_.isEmpty(props.colorMap)) return;
     const DSL = spanFiltersToDSL();
+    setDSL(DSL);
     handleSpansGanttRequest(props.traceId, props.http, setData, props.colorMap, DSL);
   }, 150);
 
@@ -159,8 +167,6 @@ export function SpanDetailPanel(props: {
     ));
   }, [spanFilters]);
 
-  const [cursorStyle, setCursorStyle] = useState({});
-
   const onHover = () => {
     const dragLayer = document.getElementsByClassName('nsewdrag')?.[0];
     dragLayer.style.cursor = 'pointer';
@@ -182,6 +188,17 @@ export function SpanDetailPanel(props: {
     },
   ];
   const [toggleIdSelected, setToggleIdSelected] = useState(toggleOptions[0].id);
+
+  const spanDetailTable = useMemo(
+    () => (
+      <SpanDetailTable
+        http={props.http}
+        DSL={DSL}
+        openFlyout={(spanId: string) => setCurrentSpan(spanId)}
+      />
+    ),
+    [DSL, setCurrentSpan]
+  );
 
   return (
     <>
@@ -218,7 +235,7 @@ export function SpanDetailPanel(props: {
               onUnhoverHandler={onUnhover}
             />
           ) : (
-            <SpanDetailTable http={props.http} />
+            spanDetailTable
           )}
         </div>
       </EuiPanel>

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -14,17 +14,30 @@
  */
 
 import { EuiHorizontalRule, EuiPanel } from '@elastic/eui';
-import React, { useMemo, useState } from 'react';
+import _ from 'lodash';
+import React, { useEffect, useMemo, useState } from 'react';
 import { CoreStart } from '../../../../../src/core/public';
+import { handleSpansGanttRequest } from '../../requests/traces_request_handler';
 import { PanelTitle } from '../common';
 import { Plt } from '../common/plots/plt';
 import { SpanDetailFlyout } from './span_detail_flyout';
 
 export function SpanDetailPanel(props: {
   http: CoreStart['http'];
-  data: { gantt: Plotly.Data[]; table: any[]; ganttMaxX: number };
+  traceId: string;
+  colorMap: any;
 }) {
-  // const [data, setData] = useState({ gantt: [], table: [], ganttMaxX: 0 });
+  const [data, setData] = useState({ gantt: [], table: [], ganttMaxX: 0 });
+
+  useEffect(() => {
+    refresh();
+  }, [props.colorMap]);
+
+  const refresh = () => {
+    if (_.isEmpty(props.colorMap)) return;
+    handleSpansGanttRequest(props.traceId, props.http, setData, props.colorMap);
+  };
+
   const getSpanDetailLayout = (plotTraces: Plotly.Data[], maxX: number): Partial<Plotly.Layout> => {
     // get unique labels from traces
     const yLabels = plotTraces
@@ -57,9 +70,9 @@ export function SpanDetailPanel(props: {
     };
   };
 
-  const layout = useMemo(() => getSpanDetailLayout(props.data.gantt, props.data.ganttMaxX), [
-    props.data.gantt,
-    props.data.ganttMaxX,
+  const layout = useMemo(() => getSpanDetailLayout(data.gantt, data.ganttMaxX), [
+    data.gantt,
+    data.ganttMaxX,
   ]);
 
   const [currentSpan, setCurrentSpan] = useState('');
@@ -78,7 +91,7 @@ export function SpanDetailPanel(props: {
         <PanelTitle title="Span detail" />
         <EuiHorizontalRule margin="m" />
         <div style={{ overflowY: 'auto', maxHeight: 500 }}>
-          <Plt data={props.data.gantt} layout={layout} onClickHandler={onClick} />
+          <Plt data={data.gantt} layout={layout} onClickHandler={onClick} />
         </div>
       </EuiPanel>
       {!!currentSpan && (

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -15,6 +15,7 @@
 
 import {
   EuiBadge,
+  EuiButtonGroup,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -25,9 +26,9 @@ import _ from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { CoreStart } from '../../../../../src/core/public';
 import { handleSpansGanttRequest } from '../../requests/traces_request_handler';
-import { PanelTitle } from '../common';
-import { Plt } from '../common/plots/plt';
+import { PanelTitle, Plt } from '../common';
 import { SpanDetailFlyout } from './span_detail_flyout';
+import { SpanDetailTable } from './span_detail_table';
 
 export function SpanDetailPanel(props: {
   http: CoreStart['http'];
@@ -170,10 +171,34 @@ export function SpanDetailPanel(props: {
     dragLayer.style.cursor = '';
   };
 
+  const toggleOptions = [
+    {
+      id: 'timeline',
+      label: 'Timeline',
+    },
+    {
+      id: 'span_list',
+      label: 'Span list',
+    },
+  ];
+  const [toggleIdSelected, setToggleIdSelected] = useState(toggleOptions[0].id);
+
   return (
     <>
       <EuiPanel>
-        <PanelTitle title="Span detail" totalItems={data.gantt.length / 2} />
+        <EuiFlexGroup>
+          <EuiFlexItem>
+            <PanelTitle title="Spans" totalItems={data.gantt.length / 2} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonGroup
+              legend="Select view of spans"
+              options={toggleOptions}
+              idSelected={toggleIdSelected}
+              onChange={(id) => setToggleIdSelected(id)}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
         {spanFilters.length > 0 && (
           <>
             <EuiSpacer size="s" />
@@ -184,13 +209,17 @@ export function SpanDetailPanel(props: {
         )}
         <EuiHorizontalRule margin="m" />
         <div style={{ overflowY: 'auto', maxHeight: 500 }}>
-          <Plt
-            data={data.gantt}
-            layout={layout}
-            onClickHandler={onClick}
-            onHoverHandler={onHover}
-            onUnhoverHandler={onUnhover}
-          />
+          {toggleIdSelected === 'timeline' ? (
+            <Plt
+              data={data.gantt}
+              layout={layout}
+              onClickHandler={onClick}
+              onHoverHandler={onHover}
+              onUnhoverHandler={onUnhover}
+            />
+          ) : (
+            <SpanDetailTable http={props.http} />
+          )}
         </div>
       </EuiPanel>
       {!!currentSpan && (

--- a/public/components/traces/span_detail_panel.tsx
+++ b/public/components/traces/span_detail_panel.tsx
@@ -28,6 +28,7 @@ export function SpanDetailPanel(props: {
   colorMap: any;
 }) {
   const [data, setData] = useState({ gantt: [], table: [], ganttMaxX: 0 });
+  const [spanFilters, setSpanFilters] = useState<any>([]);
 
   useEffect(() => {
     refresh();
@@ -78,17 +79,15 @@ export function SpanDetailPanel(props: {
   const [currentSpan, setCurrentSpan] = useState('');
 
   const onClick = (event) => {
-    console.log('event', event);
     if (!event?.points) return;
     const point = event.points[0];
-    const start = point.data.x[point.pointNumber];
     setCurrentSpan(point.data.spanId);
   };
 
   return (
     <>
       <EuiPanel>
-        <PanelTitle title="Span detail" />
+        <PanelTitle title="Span detail" totalItems={data.gantt.length / 2} />
         <EuiHorizontalRule margin="m" />
         <div style={{ overflowY: 'auto', maxHeight: 500 }}>
           <Plt data={data.gantt} layout={layout} onClickHandler={onClick} />

--- a/public/components/traces/span_detail_table.tsx
+++ b/public/components/traces/span_detail_table.tsx
@@ -152,10 +152,10 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
   );
 
   const onChangeItemsPerPage = useCallback((size) => setTableParams({ ...tableParams, size }), [
-    setTableParams,
+    tableParams, setTableParams,
   ]);
   const onChangePage = useCallback((page) => setTableParams({ ...tableParams, page }), [
-    setTableParams,
+    tableParams, setTableParams,
   ]);
 
   return (

--- a/public/components/traces/span_detail_table.tsx
+++ b/public/components/traces/span_detail_table.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiDataGrid, EuiDataGridColumn, EuiLink } from '@elastic/eui';
+import { EuiDataGrid, EuiDataGridColumn, EuiLink, EuiText } from '@elastic/eui';
 import _ from 'lodash';
 import moment from 'moment';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -127,7 +127,13 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
         case 'endTime':
           return moment(value).format(DATE_FORMAT);
         case 'status.code':
-          return value === 2 ? 'Yes' : 'No';
+          return value === 2 ? (
+            <EuiText color="danger" size="s">
+              Yes
+            </EuiText>
+          ) : (
+            'No'
+          );
 
         default:
           return value;

--- a/public/components/traces/span_detail_table.tsx
+++ b/public/components/traces/span_detail_table.tsx
@@ -13,8 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiDataGrid, EuiDataGridColumn } from '@elastic/eui';
-import _ from 'lodash';
+import { EuiDataGrid, EuiDataGridColumn, EuiLink } from '@elastic/eui';
 import moment from 'moment';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { CoreStart } from '../../../../../src/core/public';
@@ -24,6 +23,7 @@ import { nanoToMilliSec } from '../common';
 
 interface SpanDetailTableProps {
   http: CoreStart['http'];
+  openFlyout: (spanId: string) => void;
   DSL?: any;
 }
 
@@ -54,7 +54,7 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
       sortingColumns: tableParams.sortingColumns.map(({ id, direction }) => ({ [id]: direction })),
     };
     handleSpansRequest(props.http, setItems, setTotal, spanSearchParams, props.DSL);
-  }, [tableParams]);
+  }, [tableParams, props.DSL]);
 
   const columns: EuiDataGridColumn[] = [
     {
@@ -94,8 +94,10 @@ export function SpanDetailTable(props: SpanDetailTableProps) {
       let adjustedRowIndex = rowIndex - tableParams.page * tableParams.size;
       if (!items.hasOwnProperty(adjustedRowIndex)) return '-';
       const value = items[adjustedRowIndex][columnId];
-      if (_.isEmpty(value)) return '-';
+      if (value == null || value === '') return '-';
       switch (columnId) {
+        case 'spanId':
+          return <EuiLink onClick={() => props.openFlyout(value)}>{value}</EuiLink>;
         case 'durationInNanos':
           return `${nanoToMilliSec(value)} ms`;
         case 'startTime':

--- a/public/components/traces/span_detail_table.tsx
+++ b/public/components/traces/span_detail_table.tsx
@@ -1,0 +1,147 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { EuiDataGrid, EuiDataGridColumn } from '@elastic/eui';
+import _ from 'lodash';
+import moment from 'moment';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { CoreStart } from '../../../../../src/core/public';
+import { DATE_FORMAT } from '../../../common';
+import { handleSpansRequest } from '../../requests/traces_request_handler';
+import { nanoToMilliSec } from '../common';
+
+interface SpanDetailTableProps {
+  http: CoreStart['http'];
+  DSL?: any;
+}
+
+export interface SpanSearchParams {
+  from: number;
+  size: number;
+  sortingColumns: Array<{
+    [id: string]: 'asc' | 'desc';
+  }>;
+}
+
+export function SpanDetailTable(props: SpanDetailTableProps) {
+  const [tableParams, setTableParams] = useState({
+    size: 10,
+    page: 0,
+    sortingColumns: [] as Array<{
+      id: string;
+      direction: 'asc' | 'desc';
+    }>,
+  });
+  const [items, setItems] = useState<any>([]);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    const spanSearchParams: SpanSearchParams = {
+      from: tableParams.page * tableParams.size,
+      size: tableParams.size,
+      sortingColumns: tableParams.sortingColumns.map(({ id, direction }) => ({ [id]: direction })),
+    };
+    handleSpansRequest(props.http, setItems, setTotal, spanSearchParams, props.DSL);
+  }, [tableParams]);
+
+  const columns: EuiDataGridColumn[] = [
+    {
+      id: 'spanId',
+      display: 'Span ID',
+    },
+    {
+      id: 'parentSpanId',
+      display: 'Parent span ID',
+    },
+    {
+      id: 'serviceName',
+      display: 'Service',
+    },
+    {
+      id: 'name',
+      display: 'Operation',
+    },
+    {
+      id: 'durationInNanos',
+      display: 'Duration',
+    },
+    {
+      id: 'startTime',
+      display: 'Start time',
+    },
+    {
+      id: 'endTime',
+      display: 'End time',
+    },
+  ];
+
+  const [visibleColumns, setVisibleColumns] = useState(() => columns.map(({ id }) => id));
+
+  const renderCellValue = useMemo(() => {
+    return ({ rowIndex, columnId }) => {
+      let adjustedRowIndex = rowIndex - tableParams.page * tableParams.size;
+      if (!items.hasOwnProperty(adjustedRowIndex)) return '-';
+      const value = items[adjustedRowIndex][columnId];
+      if (_.isEmpty(value)) return '-';
+      switch (columnId) {
+        case 'durationInNanos':
+          return `${nanoToMilliSec(value)} ms`;
+        case 'startTime':
+        case 'endTime':
+          return moment(value).format(DATE_FORMAT);
+
+        default:
+          return value;
+      }
+    };
+  }, [items, tableParams.page, tableParams.size]);
+
+  const onSort = useCallback(
+    (sortingColumns) => {
+      setTableParams({
+        ...tableParams,
+        sortingColumns,
+      });
+    },
+    [setTableParams]
+  );
+
+  const onChangeItemsPerPage = useCallback((size) => setTableParams({ ...tableParams, size }), [
+    setTableParams,
+  ]);
+  const onChangePage = useCallback((page) => setTableParams({ ...tableParams, page }), [
+    setTableParams,
+  ]);
+
+  return (
+    <>
+      <EuiDataGrid
+        aria-labelledby="span-detail-data-grid"
+        columns={columns}
+        columnVisibility={{ visibleColumns, setVisibleColumns }}
+        rowCount={total}
+        renderCellValue={renderCellValue}
+        sorting={{ columns: tableParams.sortingColumns, onSort }}
+        pagination={{
+          pageIndex: tableParams.page,
+          pageSize: tableParams.size,
+          pageSizeOptions: [10, 50, 100],
+          onChangeItemsPerPage: onChangeItemsPerPage,
+          onChangePage: onChangePage,
+        }}
+      />
+    </>
+  );
+}

--- a/public/components/traces/trace_view.tsx
+++ b/public/components/traces/trace_view.tsx
@@ -25,13 +25,13 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
-  EuiTitle,
+  EuiTitle
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import {
   handlePayloadRequest,
   handleServicesPieChartRequest,
-  handleTraceViewRequest,
+  handleTraceViewRequest
 } from '../../requests/traces_request_handler';
 import { CoreDeps } from '../app';
 import { PanelTitle } from '../common';
@@ -117,7 +117,13 @@ export function TraceView(props: TraceViewProps) {
               <EuiFlexItem grow={false}>
                 <EuiText className="overview-title">Errors</EuiText>
                 <EuiText size="s" className="overview-content">
-                  {fields.error_count}
+                  {fields.error_count == null ? (
+                    '-'
+                  ) : fields.error_count > 0 ? (
+                    <EuiText color="danger" size="s" style={{fontWeight: 430}}>Yes</EuiText>
+                  ) : (
+                    'No'
+                  )}
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/components/traces/trace_view.tsx
+++ b/public/components/traces/trace_view.tsx
@@ -181,7 +181,7 @@ export function TraceView(props: TraceViewProps) {
               <ServiceBreakdownPanel data={serviceBreakdownData} />
             </EuiFlexItem>
             <EuiFlexItem grow={7}>
-              <SpanDetailPanel data={spanDetailData} />
+              <SpanDetailPanel http={props.http} data={spanDetailData} />
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer />

--- a/public/components/traces/trace_view.tsx
+++ b/public/components/traces/trace_view.tsx
@@ -14,7 +14,6 @@
  */
 
 import {
-  EuiButton,
   EuiButtonIcon,
   EuiCodeBlock,
   EuiCopy,
@@ -25,18 +24,17 @@ import {
   EuiPageBody,
   EuiPanel,
   EuiSpacer,
-  EuiSuperSelect,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import {
   handlePayloadRequest,
-  handleTracesChartsRequest,
+  handleServicesPieChartRequest,
   handleTraceViewRequest,
 } from '../../requests/traces_request_handler';
 import { CoreDeps } from '../app';
-import { PanelTitle, renderBenchmark } from '../common';
+import { PanelTitle } from '../common';
 import { ServiceBreakdownPanel } from './service_breakdown_panel';
 import { SpanDetailPanel } from './span_detail_panel';
 
@@ -131,8 +129,8 @@ export function TraceView(props: TraceViewProps) {
 
   const [fields, setFields] = useState({});
   const [serviceBreakdownData, setServiceBreakdownData] = useState([]);
-  const [spanDetailData, setSpanDetailData] = useState({ gantt: [], table: [], ganttMaxX: 0 });
   const [payloadData, setPayloadData] = useState('');
+  const [colorMap, setColorMap] = useState({});
 
   useEffect(() => {
     props.setBreadcrumbs([
@@ -152,16 +150,9 @@ export function TraceView(props: TraceViewProps) {
     refresh();
   }, []);
 
-  const refresh = () => {
+  const refresh = async () => {
     handleTraceViewRequest(props.traceId, props.http, fields, setFields);
-    handleTracesChartsRequest(
-      props.traceId,
-      props.http,
-      serviceBreakdownData,
-      setServiceBreakdownData,
-      spanDetailData,
-      setSpanDetailData
-    );
+    handleServicesPieChartRequest(props.traceId, props.http, setServiceBreakdownData, setColorMap);
     handlePayloadRequest(props.traceId, props.http, payloadData, setPayloadData);
   };
 
@@ -181,7 +172,7 @@ export function TraceView(props: TraceViewProps) {
               <ServiceBreakdownPanel data={serviceBreakdownData} />
             </EuiFlexItem>
             <EuiFlexItem grow={7}>
-              <SpanDetailPanel http={props.http} data={spanDetailData} />
+              <SpanDetailPanel traceId={props.traceId} http={props.http} colorMap={colorMap} />
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiSpacer />

--- a/public/components/traces/traces_table.tsx
+++ b/public/components/traces/traces_table.tsx
@@ -128,7 +128,16 @@ export function TracesTable(props: {
           name: 'Errors',
           align: 'right',
           sortable: true,
-          render: (item) => (item === 0 || item ? item : '-'),
+          render: (item) =>
+            item == null ? (
+              '-'
+            ) : item > 0 ? (
+              <EuiText color="danger" size="s">
+                Yes
+              </EuiText>
+            ) : (
+              'No'
+            ),
         },
         {
           field: 'last_updated',

--- a/public/requests/queries/traces_queries.ts
+++ b/public/requests/queries/traces_queries.ts
@@ -14,6 +14,7 @@
  */
 
 import { PropertySort } from '@elastic/eui';
+import { SpanSearchParams } from '../../components/traces/span_detail_table';
 import { TRACES_MAX_NUM } from '../../../common';
 
 export const getTraceGroupPercentilesQuery = () => {
@@ -255,6 +256,23 @@ export const getSpanFlyoutQuery = (spanId?: string, size = 1000) => {
       },
     },
   };
+};
+
+export const getSpansQuery = (spanSearchParams: SpanSearchParams) => {
+  const query: any = {
+    size: spanSearchParams.size,
+    from: spanSearchParams.from,
+    query: {
+      bool: {
+        must: [],
+        filter: [],
+        should: [],
+        must_not: [],
+      },
+    },
+    sort: spanSearchParams.sortingColumns,
+  };
+  return query;
 };
 
 export const getValidTraceIdsQuery = (DSL) => {

--- a/public/requests/queries/traces_queries.ts
+++ b/public/requests/queries/traces_queries.ts
@@ -237,6 +237,26 @@ export const getPayloadQuery = (traceId: string, size = 1000) => {
   };
 };
 
+export const getSpanFlyoutQuery = (spanId?: string, size = 1000) => {
+  return {
+    size,
+    query: {
+      bool: {
+        must: [
+          {
+            term: {
+              spanId,
+            },
+          },
+        ],
+        filter: [],
+        should: [],
+        must_not: [],
+      },
+    },
+  };
+};
+
 export const getValidTraceIdsQuery = (DSL) => {
   const query: any = {
     size: 0,

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -222,7 +222,7 @@ const hitsToSpanDetailData = async (hits, colorMap) => {
       end_time: hit._source.endTime,
     });
     data.gantt.push(
-      {  // transparent bar for positioning gantt chart bar
+      {
         x: [startTime],
         y: [uniqueLabel],
         marker: {
@@ -235,7 +235,7 @@ const hitsToSpanDetailData = async (hits, colorMap) => {
         showlegend: false,
         spanId: hit._source.spanId,
       },
-      {  // actual bar visible for gantt chart
+      {
         x: [duration],
         y: [uniqueLabel],
         text: [error],
@@ -249,30 +249,11 @@ const hitsToSpanDetailData = async (hits, colorMap) => {
         orientation: 'h',
         hovertemplate: '%{x}<extra></extra>',
         spanId: hit._source.spanId,
-      },
-      {  // transparent bar after, for easier clicking
-        x: [startTime + duration],
-        y: [uniqueLabel],
-        marker: {
-          color: 'rgba(0, 0, 0, 0)',
-        },
-        width: 0.4,
-        type: 'bar',
-        orientation: 'h',
-        hoverinfo: 'none',
-        showlegend: false,
-        spanId: hit._source.spanId,
-      },
+      }
     );
   });
-  
-  data.ganttMaxX = maxEndTime;
 
-  // third bar for easier clicking should not exceed maxEndTime
-  for (let i = 2; i < data.gantt.length; i+=3) {
-    const thirdBar = data.gantt[i];
-    thirdBar.x[0] = maxEndTime - thirdBar.x[0];
-  }
+  data.ganttMaxX = maxEndTime;
   return data;
 };
 

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -175,8 +175,14 @@ export const handleServicesPieChartRequest = async (
     .catch((error) => console.error(error));
 };
 
-export const handleSpansGanttRequest = (traceId, http, setSpanDetailData, colorMap) => {
-  handleDslRequest(http, null, getSpanDetailQuery(traceId))
+export const handleSpansGanttRequest = (
+  traceId,
+  http,
+  setSpanDetailData,
+  colorMap,
+  spanFiltersDSL
+) => {
+  handleDslRequest(http, spanFiltersDSL, getSpanDetailQuery(traceId))
     .then((response) => hitsToSpanDetailData(response.hits.hits, colorMap))
     .then((newItems) => setSpanDetailData(newItems))
     .catch((error) => console.error(error));

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -15,7 +15,7 @@
 
 import _ from 'lodash';
 import moment from 'moment';
-import { SpanSearchParams } from 'public/components/traces/span_details_table';
+import { SpanSearchParams } from '../components/traces/span_detail_table';
 import { v1 as uuid } from 'uuid';
 import { DATE_FORMAT } from '../../common';
 import { nanoToMilliSec } from '../components/common';
@@ -267,9 +267,10 @@ export const handleSpansRequest = (
   http,
   setItems,
   setTotal,
-  spanSearchParams: SpanSearchParams
+  spanSearchParams: SpanSearchParams,
+  DSL,
 ) => {
-  handleDslRequest(http, null, getSpansQuery(spanSearchParams))
+  handleDslRequest(http, DSL, getSpansQuery(spanSearchParams))
     .then((response) => {
       setItems(response.hits.hits.map((hit) => hit._source));
       setTotal(response.hits.total?.value || 0);

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -271,7 +271,6 @@ export const handleSpansRequest = (
 ) => {
   handleDslRequest(http, null, getSpansQuery(spanSearchParams))
     .then((response) => {
-      console.log('response', response);
       setItems(response.hits.hits.map((hit) => hit._source));
       setTotal(response.hits.total?.value || 0);
     })

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -191,7 +191,7 @@ const hitsToSpanDetailData = async (hits, colorMap) => {
     const duration = _.round(nanoToMilliSec(hit._source.durationInNanos), 2);
     const serviceName = _.get(hit, ['_source', 'serviceName']);
     const name = _.get(hit, '_source.name');
-    const error = hit._source['status.code'] ? 'Error' : '';
+    const error = hit._source['status.code'] === 2 ? 'Error' : '';
     const uniqueLabel = `${serviceName} <br>${name} ` + uuid();
     maxEndTime = Math.max(maxEndTime, startTime + duration);
 

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -75,7 +75,7 @@ export const handleTracesRequest = async (http, DSL, timeFilterDSL, items, setIt
             trace_group: bucket.trace_group.buckets[0]?.key,
             latency: bucket.latency.value,
             last_updated: moment(bucket.last_updated.value).format(DATE_FORMAT),
-            error_count: bucket.error_count.doc_count > 0 ? 'Yes' : 'No',
+            error_count: bucket.error_count.doc_count,
             percentile_in_trace_group: binarySearch(
               percentileRanges[bucket.trace_group.buckets[0]?.key],
               bucket.latency.value
@@ -103,7 +103,7 @@ export const handleTraceViewRequest = (traceId, http, fields, setFields) => {
         latency: bucket.latency.value,
         latency_vs_benchmark: 'N/A',
         percentile_in_trace_group: 'N/A',
-        error_count: bucket.error_count.doc_count > 0 ? 'Yes' : 'No',
+        error_count: bucket.error_count.doc_count,
         errors_vs_benchmark: 'N/A',
       };
     })

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -191,7 +191,7 @@ export const handleSpansGanttRequest = (
 export const handleSpansFlyoutRequest = (http, spanId, setItems) => {
   handleDslRequest(http, null, getSpanFlyoutQuery(spanId))
     .then((response) => {
-      setItems(response?.hits.hits?.[0]._source);
+      setItems(response?.hits.hits?.[0]?._source);
     })
     .catch((error) => console.error(error));
 };

--- a/public/requests/traces_request_handler.ts
+++ b/public/requests/traces_request_handler.ts
@@ -222,7 +222,7 @@ const hitsToSpanDetailData = async (hits, colorMap) => {
       end_time: hit._source.endTime,
     });
     data.gantt.push(
-      {
+      {  // transparent bar for positioning gantt chart bar
         x: [startTime],
         y: [uniqueLabel],
         marker: {
@@ -235,7 +235,7 @@ const hitsToSpanDetailData = async (hits, colorMap) => {
         showlegend: false,
         spanId: hit._source.spanId,
       },
-      {
+      {  // actual bar visible for gantt chart
         x: [duration],
         y: [uniqueLabel],
         text: [error],
@@ -249,11 +249,30 @@ const hitsToSpanDetailData = async (hits, colorMap) => {
         orientation: 'h',
         hovertemplate: '%{x}<extra></extra>',
         spanId: hit._source.spanId,
-      }
+      },
+      {  // transparent bar after, for easier clicking
+        x: [startTime + duration],
+        y: [uniqueLabel],
+        marker: {
+          color: 'rgba(0, 0, 0, 0)',
+        },
+        width: 0.4,
+        type: 'bar',
+        orientation: 'h',
+        hoverinfo: 'none',
+        showlegend: false,
+        spanId: hit._source.spanId,
+      },
     );
   });
-
+  
   data.ganttMaxX = maxEndTime;
+
+  // third bar for easier clicking should not exceed maxEndTime
+  for (let i = 2; i < data.gantt.length; i+=3) {
+    const thirdBar = data.gantt[i];
+    thirdBar.x[0] = maxEndTime - thirdBar.x[0];
+  }
   return data;
 };
 


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/opensearch-project/trace-analytics/issues/15
- #36 

*Description of changes:*
- use sessionstorage instead of localstorage, filters are no longer preserved for different sessions
- Add flyout to display span information with filtering
- Add data grid to display spans in trace and service view
- Will add more IT and UT tests later

![image](https://user-images.githubusercontent.com/28062824/119055690-52236000-b97e-11eb-8602-e08cb2569a1f.png)

![image](https://user-images.githubusercontent.com/28062824/119055615-3455fb00-b97e-11eb-9f08-6cb041634646.png)


 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 